### PR TITLE
docs: document selectable memory backends and managed setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,14 @@ server requires them.
 
 ## Examples
 
-All examples run via `adk web` and ship with a README and `.env.example`. See the [Examples index](https://redis-developer.github.io/adk-redis/examples/) for descriptions.
+Each example ships with a README and `.env.example`. Memory and session
+examples that register services through `get_service_registry()` run via
+`python main.py`; tools-only and search examples run via `adk web`. See each
+example's README and the [Examples index](https://redis-developer.github.io/adk-redis/examples/) for the runner and backend each uses.
 
 | Category | Examples |
 |---|---|
-| **Memory and sessions** | [`simple_redis_memory`](examples/simple_redis_memory/) · [`travel_agent_memory_hybrid`](examples/travel_agent_memory_hybrid/) · [`travel_agent_memory_tools`](examples/travel_agent_memory_tools/) · [`fitness_coach_mcp`](examples/fitness_coach_mcp/) |
+| **Memory and sessions** | [`managed_memory_quickstart`](examples/managed_memory_quickstart/) · [`simple_redis_memory`](examples/simple_redis_memory/) · [`travel_agent_memory_hybrid`](examples/travel_agent_memory_hybrid/) · [`travel_agent_memory_tools`](examples/travel_agent_memory_tools/) · [`fitness_coach_mcp`](examples/fitness_coach_mcp/) |
 | **Search** | [`redis_search_tools`](examples/redis_search_tools/) · [`redis_sql_search`](examples/redis_sql_search/) · [`redisvl_mcp_search`](examples/redisvl_mcp_search/) |
 | **Caching** | [`semantic_cache`](examples/semantic_cache/) · [`langcache_cache`](examples/langcache_cache/) |
 

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -11,8 +11,8 @@ The LLM decides when to search, create, update, or delete memories.
 |---------|---------|
 | **Protocol** | MCP (via SSE or Streamable HTTP) or REST-based ADK tools |
 | **Control** | LLM-driven: the agent chooses when to remember and recall |
-| **Session storage** | Agent Memory Server working memory |
-| **Long-term memory** | Agent Memory Server with vector + full-text indexes |
+| **Session storage** | Redis Agent Memory or Agent Memory Server working memory |
+| **Long-term memory** | Redis Agent Memory or Agent Memory Server with vector + full-text indexes |
 | **Language support** | MCP works with Python, TypeScript, and any MCP-compatible client |
 
 ## How It Works
@@ -25,7 +25,7 @@ flowchart TD
     MCP -->|MCP| MCPS[McpToolset<br/>search · create · prompt]
     MCP -->|REST| REST[Memory Tools<br/>SearchMemoryTool · CreateMemoryTool]
 
-    MCPS --> AMS[Agent Memory Server]
+    MCPS --> AMS["Redis Agent Memory<br/>or Agent Memory Server"]
     REST --> AMS
 
     AMS --> WM[Working Memory]
@@ -44,6 +44,12 @@ flowchart TD
 ```
 
 Unlike the [services approach](sessions.md), where the framework handles memory automatically, here the LLM explicitly calls memory tools during reasoning. This gives you fine-grained control over what gets stored and retrieved.
+
+!!! note "MCP requires the self-hosted server"
+    The SDK tools (Option 2) target either Redis Agent Memory
+    (`redis-agent-memory`) or the self-hosted Agent Memory Server
+    (`opensource-agent-memory`). The MCP path (Option 1) is provided only by the
+    self-hosted Agent Memory Server; the managed backend has no MCP endpoint.
 
 ## Option 1: MCP Tools
 
@@ -101,8 +107,10 @@ from adk_redis import (
     MemoryToolConfig,
 )
 
+from adk_redis import REDIS_AGENT_MEMORY_BACKEND
+
 config = MemoryToolConfig(
-    backend="redis-agent-memory",
+    backend=REDIS_AGENT_MEMORY_BACKEND,  # alias for "redis-agent-memory"
     api_base_url="http://localhost:8000",
     api_key="...",
     store_id="...",
@@ -155,6 +163,11 @@ agent = Agent(
 | `search_top_k` | `10` | Default max search results |
 | `distance_threshold` | `None` | Compatibility alias for search threshold |
 | `deduplicate` | `True` | Deduplicate when creating memories |
+
+For `backend`, you can pass the `"redis-agent-memory"` /
+`"opensource-agent-memory"` strings directly, or import the typo-safe
+`REDIS_AGENT_MEMORY_BACKEND` / `OPENSOURCE_AGENT_MEMORY_BACKEND` constants (or
+the `MemoryBackendName` type) from `adk_redis`.
 
 Launch with the [ADK web UI](https://google.github.io/adk-docs/runtime/) for interactive testing:
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -26,6 +26,7 @@ For task-oriented recipes, browse the
 ## How-to guides
 
 - [Redis setup](user_guide/how_to_guides/redis_setup.md): start Redis 8.4 locally or in Redis Cloud.
+- [Managed memory setup](user_guide/how_to_guides/managed_memory_setup.md): connect to the managed Redis Agent Memory backend.
 - [Memory server setup](user_guide/how_to_guides/memory_server_setup.md): run Agent Memory Server.
 - [Session service](user_guide/how_to_guides/session_service.md): wire `RedisWorkingMemorySessionService`.
 - [Memory service](user_guide/how_to_guides/memory_service.md): wire `RedisLongTermMemoryService`.
@@ -59,6 +60,9 @@ When generating code that uses adk-redis:
   (`RedisLongTermMemoryServiceConfig`, etc.) so options are explicit.
 - Set `backend="redis-agent-memory"` for Redis Agent Memory, or
   `backend="opensource-agent-memory"` for the open source self-hosted server.
+  For typo-safety, import the `REDIS_AGENT_MEMORY_BACKEND` and
+  `OPENSOURCE_AGENT_MEMORY_BACKEND` constants (or the `MemoryBackendName` type)
+  from `adk_redis` instead of writing the strings inline.
 - For the RedisVL MCP path, use ADK's native `McpToolset` with the
   appropriate `*ConnectionParams` class. Set
   `tool_filter=["search-records"]` to suppress writes, or pass

--- a/docs/user_guide/01_integration.md
+++ b/docs/user_guide/01_integration.md
@@ -12,14 +12,17 @@ Provide Redis Agent Memory connection settings:
 
 ```bash
 export REDIS_MEMORY_BACKEND="redis-agent-memory"
-export AGENT_MEMORY_SERVER_URL="https://..."
-export AGENT_MEMORY_STORE_ID="..."
-export AGENT_MEMORY_API_KEY="..."
+export REDIS_AGENT_MEMORY_API_BASE_URL="https://..."
+export REDIS_AGENT_MEMORY_STORE_ID="..."
+export REDIS_AGENT_MEMORY_API_KEY="..."
 ```
 
-For the open source self-hosted Agent Memory Server, use
-`REDIS_MEMORY_BACKEND="opensource-agent-memory"` and point
-`AGENT_MEMORY_SERVER_URL` at your server.
+These are the same variable names used by the
+[managed memory quickstart](how_to_guides/managed_memory_setup.md) and the
+integration tests. For the open source self-hosted Agent Memory Server, use
+`REDIS_MEMORY_BACKEND="opensource-agent-memory"`, point
+`REDIS_AGENT_MEMORY_API_BASE_URL` at your server, and omit the API key and
+store ID unless your deployment requires them.
 
 ## 2. Install dependencies
 
@@ -38,28 +41,33 @@ from google.adk.runners import Runner
 from google.adk.tools import load_memory
 from google.adk.tools import preload_memory
 from adk_redis import (
+    REDIS_AGENT_MEMORY_BACKEND,
     RedisWorkingMemorySessionService,
     RedisWorkingMemorySessionServiceConfig,
     RedisLongTermMemoryService,
     RedisLongTermMemoryServiceConfig,
 )
 
+# REDIS_AGENT_MEMORY_BACKEND and OPENSOURCE_AGENT_MEMORY_BACKEND are typo-safe
+# aliases for the "redis-agent-memory" and "opensource-agent-memory" strings.
+backend = os.getenv("REDIS_MEMORY_BACKEND", REDIS_AGENT_MEMORY_BACKEND)
+
 session_service = RedisWorkingMemorySessionService(
     config=RedisWorkingMemorySessionServiceConfig(
-        backend=os.getenv("REDIS_MEMORY_BACKEND", "redis-agent-memory"),
-        api_base_url=os.environ["AGENT_MEMORY_SERVER_URL"],
-        api_key=os.environ.get("AGENT_MEMORY_API_KEY"),
-        store_id=os.environ.get("AGENT_MEMORY_STORE_ID"),
+        backend=backend,
+        api_base_url=os.environ["REDIS_AGENT_MEMORY_API_BASE_URL"],
+        api_key=os.environ.get("REDIS_AGENT_MEMORY_API_KEY"),
+        store_id=os.environ.get("REDIS_AGENT_MEMORY_STORE_ID"),
         default_namespace="my_app",
     )
 )
 
 memory_service = RedisLongTermMemoryService(
     config=RedisLongTermMemoryServiceConfig(
-        backend=os.getenv("REDIS_MEMORY_BACKEND", "redis-agent-memory"),
-        api_base_url=os.environ["AGENT_MEMORY_SERVER_URL"],
-        api_key=os.environ.get("AGENT_MEMORY_API_KEY"),
-        store_id=os.environ.get("AGENT_MEMORY_STORE_ID"),
+        backend=backend,
+        api_base_url=os.environ["REDIS_AGENT_MEMORY_API_BASE_URL"],
+        api_key=os.environ.get("REDIS_AGENT_MEMORY_API_KEY"),
+        store_id=os.environ.get("REDIS_AGENT_MEMORY_STORE_ID"),
         default_namespace="my_app",
     )
 )

--- a/docs/user_guide/how_to_guides/index.md
+++ b/docs/user_guide/how_to_guides/index.md
@@ -14,6 +14,12 @@ Task-oriented recipes for adk-redis.
 
     Stand up a local Redis 8 instance for ADK agents.
 
+-   :material-cloud:{ .lg .middle } **[Managed memory setup](managed_memory_setup.md)**
+
+    ---
+
+    Connect to the managed Redis Agent Memory backend (the library default).
+
 -   :material-server-network:{ .lg .middle } **[Memory server setup](memory_server_setup.md)**
 
     ---

--- a/docs/user_guide/how_to_guides/managed_memory_setup.md
+++ b/docs/user_guide/how_to_guides/managed_memory_setup.md
@@ -1,0 +1,103 @@
+# Managed Redis Agent Memory Setup
+
+This guide covers the **managed** `redis-agent-memory` backend, which is the
+library default. For the self-hosted alternative, see
+[Agent Memory Server setup](memory_server_setup.md).
+
+The managed backend is a hosted Redis Agent Memory data plane: there is no
+local Agent Memory Server, worker, or Docker setup to run. You connect to it
+with an API base URL, an API key, and a store ID.
+
+## Credentials
+
+The managed backend requires three values from your Redis Agent Memory
+deployment:
+
+| Value | Config field | Environment variable |
+|-------|--------------|----------------------|
+| API base URL | `api_base_url` | `REDIS_AGENT_MEMORY_API_BASE_URL` |
+| API key | `api_key` | `REDIS_AGENT_MEMORY_API_KEY` |
+| Store ID | `store_id` | `REDIS_AGENT_MEMORY_STORE_ID` |
+
+These are the same variable names used by the
+[managed memory quickstart example](https://github.com/redis-developer/adk-redis/tree/main/examples/managed_memory_quickstart)
+and the integration tests.
+
+```bash
+export REDIS_MEMORY_BACKEND="redis-agent-memory"
+export REDIS_AGENT_MEMORY_API_BASE_URL="https://..."
+export REDIS_AGENT_MEMORY_API_KEY="..."
+export REDIS_AGENT_MEMORY_STORE_ID="..."
+```
+
+## Wiring the services
+
+```python
+import os
+
+from adk_redis import (
+    REDIS_AGENT_MEMORY_BACKEND,
+    RedisLongTermMemoryService,
+    RedisLongTermMemoryServiceConfig,
+    RedisWorkingMemorySessionService,
+    RedisWorkingMemorySessionServiceConfig,
+)
+
+session_service = RedisWorkingMemorySessionService(
+    config=RedisWorkingMemorySessionServiceConfig(
+        backend=REDIS_AGENT_MEMORY_BACKEND,
+        api_base_url=os.environ["REDIS_AGENT_MEMORY_API_BASE_URL"],
+        api_key=os.environ["REDIS_AGENT_MEMORY_API_KEY"],
+        store_id=os.environ["REDIS_AGENT_MEMORY_STORE_ID"],
+        default_namespace="my_app",
+    )
+)
+
+memory_service = RedisLongTermMemoryService(
+    config=RedisLongTermMemoryServiceConfig(
+        backend=REDIS_AGENT_MEMORY_BACKEND,
+        api_base_url=os.environ["REDIS_AGENT_MEMORY_API_BASE_URL"],
+        api_key=os.environ["REDIS_AGENT_MEMORY_API_KEY"],
+        store_id=os.environ["REDIS_AGENT_MEMORY_STORE_ID"],
+        default_namespace="my_app",
+    )
+)
+```
+
+`REDIS_AGENT_MEMORY_BACKEND` is a typo-safe alias for the
+`"redis-agent-memory"` string. Either form works.
+
+## Identifier constraints
+
+The managed API accepts only alphanumeric characters and hyphens
+(`[A-Za-z0-9-]`) in identifier fields such as namespace, session ID, and actor
+ID, and caps session IDs at 64 characters. `adk-redis` adapts ADK identifiers
+to fit:
+
+- Namespaces and authors are sanitized: unsupported characters (including `_`
+  and `:`) are replaced with hyphens. For example, `my_app` becomes `my-app`.
+- ADK session IDs that exceed the limit or contain unsupported characters are
+  hashed to a stable hex value that fits the 64-character cap.
+
+This adaptation is automatic. You do not need to pre-sanitize identifiers, but
+be aware that two raw namespaces that differ only by an unsupported character
+(for example `my_app` and `my-app`) collapse to the same managed namespace.
+
+## Differences from the self-hosted backend
+
+The managed backend intentionally omits features that depend on a self-hosted
+Agent Memory Server:
+
+- No auto-summarization, extraction strategies, or recency-boosted search.
+- No MCP endpoint. MCP memory tools require the
+  [Agent Memory Server](memory_server_setup.md).
+
+For a runnable minimal agent on the managed backend, see the
+[managed memory quickstart example](https://github.com/redis-developer/adk-redis/tree/main/examples/managed_memory_quickstart).
+
+## Next steps
+
+- [Session service](session_service.md) and [Memory service](memory_service.md)
+  for full configuration options.
+- [Agent Memory Server setup](memory_server_setup.md) for the self-hosted
+  backend with summarization, extraction, and MCP.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -172,6 +172,7 @@ nav:
       - How-To Guides:
           - user_guide/how_to_guides/index.md
           - Redis setup: user_guide/how_to_guides/redis_setup.md
+          - Managed memory setup: user_guide/how_to_guides/managed_memory_setup.md
           - Memory server setup: user_guide/how_to_guides/memory_server_setup.md
           - Session service: user_guide/how_to_guides/session_service.md
           - Memory service: user_guide/how_to_guides/memory_service.md


### PR DESCRIPTION
## Summary

Documentation updates reflecting the selectable memory backends (managed `redis-agent-memory` vs. self-hosted `opensource-agent-memory`) from #16.

> Depends on #17, which makes the backend constants public. The Python snippets here import `REDIS_AGENT_MEMORY_BACKEND` / `OPENSOURCE_AGENT_MEMORY_BACKEND` from `adk_redis`; those resolve once #17 lands. Merge #17 first.

## Changes

- **Env var reconciliation** (`docs/user_guide/01_integration.md`): use canonical `REDIS_AGENT_MEMORY_*` names (with `AGENT_MEMORY_*` fallbacks), matching the examples and integration tests.
- **Managed setup how-to** (`docs/user_guide/how_to_guides/managed_memory_setup.md`, new): step-by-step setup for the managed backend; wired into nav (`mkdocs.yml`) and the how-to index.
- **Stale framing fixes** (`docs/concepts/memory.md`): Quick Reference and architecture diagram now reflect both backends instead of "Agent Memory Server only".
- **Public constants advertised** (`docs/llms.txt`, config snippets): document `REDIS_AGENT_MEMORY_BACKEND` / `OPENSOURCE_AGENT_MEMORY_BACKEND` / `MemoryBackendName`. String literals remain equally valid.
- **README**: add `managed_memory_quickstart` to the examples matrix; correct the "all examples run via `adk web`" claim (some run via `python main.py` through `get_service_registry()`).

## Validation

`mkdocs build --strict` passes (no nav/link warnings for the new page).
