### PR TITLE
chore(release): finalize 0.0.7 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `session_service`, `memory_server_setup`, and `redis_setup` to
   reflect the backend choice.
 - New how-to `docs/user_guide/how_to_guides/managed_memory_setup.md` for the
-  managed Redis Agent Memory backend, wired into the nav and how-to index.
+  managed Redis Agent Memory backend, wired into the nav and how-to index. Adds
+  a Prerequisites/install line and a "Get credentials" section pointing to the
+  Redis Cloud Agent Memory create-service, view-service, and use-API pages.
 - Reconciled environment variable names to the canonical `REDIS_AGENT_MEMORY_*`
-  (with `AGENT_MEMORY_*` fallbacks) across `docs/user_guide/01_integration.md`
-  and the integration tests.
+  (with `AGENT_MEMORY_*` fallbacks) across `docs/user_guide/01_integration.md`,
+  the `simple_redis_memory` example (`main.py` + README), and the integration
+  tests.
 - README documents the `managed_memory_quickstart` example and clarifies which
   examples run via `python main.py` versus `adk web`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.0.7] - 2026-06-02
+## [0.0.7] - 2026-06-18
 
 ### Added
 
@@ -35,6 +35,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `REDIS_AGENT_MEMORY_API_BASE_URL` / `REDIS_AGENT_MEMORY_API_KEY` /
   `REDIS_AGENT_MEMORY_STORE_ID` or `AGENT_MEMORY_SERVER_URL` are not
   set.
+- Public backend selectors `REDIS_AGENT_MEMORY_BACKEND`,
+  `OPENSOURCE_AGENT_MEMORY_BACKEND`, and the `MemoryBackendName` type are
+  re-exported from `adk_redis` and `adk_redis.memory` for typo-safe backend
+  selection.
+- New `managed_memory_quickstart` example demonstrating the managed
+  `redis-agent-memory` backend wired through `get_service_registry()`.
+
+### Fixed
+
+- `UpdateMemoryTool` now applies the configured `default_namespace`,
+  `default_owner_id`, and `default_user_id` when the caller omits them on the
+  managed `redis-agent-memory` backend.
+- `RedisLongTermMemoryService` derives the events memory ID from event ids and
+  timestamps instead of `len(events)`, preventing collisions between distinct
+  event batches of equal length.
+- Session and namespace identifiers are sanitized for the managed backend,
+  which rejects `-` and `:` characters and enforces length limits; empty
+  sessions are returned before the first event so the first message can flow.
 
 ### Changed
 
@@ -50,6 +68,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   the `docs/user_guide/` how-to guides for `memory_service`,
   `session_service`, `memory_server_setup`, and `redis_setup` to
   reflect the backend choice.
+- New how-to `docs/user_guide/how_to_guides/managed_memory_setup.md` for the
+  managed Redis Agent Memory backend, wired into the nav and how-to index.
+- Reconciled environment variable names to the canonical `REDIS_AGENT_MEMORY_*`
+  (with `AGENT_MEMORY_*` fallbacks) across `docs/user_guide/01_integration.md`
+  and the integration tests.
+- README documents the `managed_memory_quickstart` example and clarifies which
+  examples run via `python main.py` versus `adk web`.
 
 ## [0.0.6] - 2026-05-20
 

--- a/docs/user_guide/how_to_guides/managed_memory_setup.md
+++ b/docs/user_guide/how_to_guides/managed_memory_setup.md
@@ -8,10 +8,17 @@ The managed backend is a hosted Redis Agent Memory data plane: there is no
 local Agent Memory Server, worker, or Docker setup to run. You connect to it
 with an API base URL, an API key, and a store ID.
 
+## Prerequisites
+
+- Python 3.10+
+- `adk-redis` with the memory extra: `pip install "adk-redis[memory]"`.
+- A managed Redis Agent Memory service on Redis Cloud (see
+  [Get credentials](#get-credentials) below).
+
 ## Credentials
 
-The managed backend requires three values from your Redis Agent Memory
-deployment:
+The managed backend requires three values from your managed Redis Agent Memory
+service:
 
 | Value | Config field | Environment variable |
 |-------|--------------|----------------------|
@@ -22,6 +29,24 @@ deployment:
 These are the same variable names used by the
 [managed memory quickstart example](https://github.com/redis-developer/adk-redis/tree/main/examples/managed_memory_quickstart)
 and the integration tests.
+
+### Get credentials
+
+Managed Redis Agent Memory is provisioned through Redis Cloud:
+
+1. **Create the service.** In the Redis Cloud console, create an Agent Memory
+   service. Quick create sets one up against a Free 30MB database if you do not
+   already have one. See
+   [Create an Agent Memory service](https://redis.io/docs/latest/operate/rc/context-engine/agent-memory/create-service/).
+   The service API key is shown **only once** at creation time, so copy it
+   immediately. If you lose it, generate a new one.
+2. **Find the endpoint and store ID.** Open the service's **Configuration** page
+   (General settings). The **Endpoint** is your `REDIS_AGENT_MEMORY_API_BASE_URL`
+   and the **Store ID** is your `REDIS_AGENT_MEMORY_STORE_ID`. See
+   [View and manage Agent Memory service](https://redis.io/docs/latest/operate/rc/context-engine/agent-memory/view-service/).
+3. **Manage API keys.** Generate or rotate the API key
+   (`REDIS_AGENT_MEMORY_API_KEY`) from the service's **API keys** tab. See
+   [Use the Agent Memory API](https://redis.io/docs/latest/operate/rc/context-engine/agent-memory/use-agent-memory/).
 
 ```bash
 export REDIS_MEMORY_BACKEND="redis-agent-memory"

--- a/examples/simple_redis_memory/README.md
+++ b/examples/simple_redis_memory/README.md
@@ -116,8 +116,9 @@ REDIS_MEMORY_EXTRACTION_STRATEGY=discrete
 REDIS_MEMORY_CONTEXT_WINDOW=8000
 REDIS_MEMORY_RECENCY_BOOST=true
 # Required only when REDIS_MEMORY_BACKEND=redis-agent-memory
-AGENT_MEMORY_STORE_ID=
-AGENT_MEMORY_API_KEY=
+# See the managed setup guide for where to obtain these values.
+REDIS_AGENT_MEMORY_STORE_ID=
+REDIS_AGENT_MEMORY_API_KEY=
 ```
 
 ## Usage
@@ -177,8 +178,8 @@ User: What's my favorite coffee?
 |----------|---------|-------------|
 | `REDIS_MEMORY_BACKEND` | `opensource-agent-memory` | `opensource-agent-memory` or `redis-agent-memory` |
 | `REDIS_MEMORY_SERVER_URL` | `http://localhost:8088` | Memory server URL |
-| `AGENT_MEMORY_STORE_ID` | empty | Redis Agent Memory store ID, used only for `redis-agent-memory` |
-| `AGENT_MEMORY_API_KEY` | empty | Redis Agent Memory API key, used only for `redis-agent-memory` |
+| `REDIS_AGENT_MEMORY_STORE_ID` | empty | Managed store ID, used only for `redis-agent-memory` (legacy `AGENT_MEMORY_STORE_ID` still accepted) |
+| `REDIS_AGENT_MEMORY_API_KEY` | empty | Managed API key, used only for `redis-agent-memory` (legacy `AGENT_MEMORY_API_KEY` still accepted) |
 | `REDIS_MEMORY_NAMESPACE` | `adk_agent_memory` | Namespace for isolation |
 | `REDIS_MEMORY_EXTRACTION_STRATEGY` | `discrete` | `discrete`, `summary`, `preferences` |
 | `REDIS_MEMORY_CONTEXT_WINDOW` | `8000` | Max tokens before summarization |

--- a/examples/simple_redis_memory/main.py
+++ b/examples/simple_redis_memory/main.py
@@ -52,6 +52,24 @@ def parse_base_url(uri: str) -> str:
   )
 
 
+def get_managed_credential(*env_names: str) -> str | None:
+  """Return the first set value among the given environment variables.
+
+  Args:
+    *env_names: Environment variable names in priority order. The canonical
+      ``REDIS_AGENT_MEMORY_*`` name should come first, with any legacy
+      ``AGENT_MEMORY_*`` name as a fallback.
+
+  Returns:
+    The first non-empty value, or ``None`` if none are set.
+  """
+  for name in env_names:
+    value = os.getenv(name)
+    if value:
+      return value
+  return None
+
+
 def redis_session_factory(uri: str, **kwargs):
   """Factory function for creating RedisWorkingMemorySessionService from URI."""
   base_url = parse_base_url(uri)
@@ -60,8 +78,12 @@ def redis_session_factory(uri: str, **kwargs):
           "REDIS_MEMORY_BACKEND", OPENSOURCE_AGENT_MEMORY_BACKEND
       ),
       api_base_url=base_url,
-      api_key=os.getenv("AGENT_MEMORY_API_KEY"),
-      store_id=os.getenv("AGENT_MEMORY_STORE_ID"),
+      api_key=get_managed_credential(
+          "REDIS_AGENT_MEMORY_API_KEY", "AGENT_MEMORY_API_KEY"
+      ),
+      store_id=get_managed_credential(
+          "REDIS_AGENT_MEMORY_STORE_ID", "AGENT_MEMORY_STORE_ID"
+      ),
       default_namespace=os.getenv("REDIS_MEMORY_NAMESPACE", "adk_agent_memory"),
       model_name=os.getenv("REDIS_MEMORY_MODEL_NAME", "gpt-4o"),
       context_window_max=int(os.getenv("REDIS_MEMORY_CONTEXT_WINDOW", "8000")),
@@ -80,8 +102,12 @@ def redis_memory_factory(uri: str, **kwargs):
           "REDIS_MEMORY_BACKEND", OPENSOURCE_AGENT_MEMORY_BACKEND
       ),
       api_base_url=base_url,
-      api_key=os.getenv("AGENT_MEMORY_API_KEY"),
-      store_id=os.getenv("AGENT_MEMORY_STORE_ID"),
+      api_key=get_managed_credential(
+          "REDIS_AGENT_MEMORY_API_KEY", "AGENT_MEMORY_API_KEY"
+      ),
+      store_id=get_managed_credential(
+          "REDIS_AGENT_MEMORY_STORE_ID", "AGENT_MEMORY_STORE_ID"
+      ),
       default_namespace=os.getenv("REDIS_MEMORY_NAMESPACE", "adk_agent_memory"),
       extraction_strategy=os.getenv(
           "REDIS_MEMORY_EXTRACTION_STRATEGY", "discrete"

--- a/examples/simple_redis_memory/main.py
+++ b/examples/simple_redis_memory/main.py
@@ -33,6 +33,7 @@ from google.adk.cli.service_registry import get_service_registry
 import uvicorn
 
 from adk_redis import OPENSOURCE_AGENT_MEMORY_BACKEND
+from adk_redis import REDIS_AGENT_MEMORY_BACKEND
 from adk_redis.memory import RedisLongTermMemoryService
 from adk_redis.memory import RedisLongTermMemoryServiceConfig
 from adk_redis.sessions import RedisWorkingMemorySessionService
@@ -70,20 +71,54 @@ def get_managed_credential(*env_names: str) -> str | None:
   return None
 
 
+def resolve_managed_credentials(backend: str) -> tuple[str | None, str | None]:
+  """Resolve the managed API key and store ID for the selected backend.
+
+  The managed ``redis-agent-memory`` backend requires both values; this raises
+  if either is missing so the failure is loud and actionable rather than a
+  cryptic auth error on the first request. The opensource backend ignores them,
+  so they are returned as ``None`` without validation.
+
+  Args:
+    backend: The selected memory backend name.
+
+  Returns:
+    A ``(api_key, store_id)`` tuple.
+
+  Raises:
+    ValueError: If the managed backend is selected but a value is missing.
+  """
+  api_key = get_managed_credential(
+      "REDIS_AGENT_MEMORY_API_KEY", "AGENT_MEMORY_API_KEY"
+  )
+  store_id = get_managed_credential(
+      "REDIS_AGENT_MEMORY_STORE_ID", "AGENT_MEMORY_STORE_ID"
+  )
+  if backend == REDIS_AGENT_MEMORY_BACKEND:
+    missing = []
+    if not api_key:
+      missing.append("REDIS_AGENT_MEMORY_API_KEY")
+    if not store_id:
+      missing.append("REDIS_AGENT_MEMORY_STORE_ID")
+    if missing:
+      raise ValueError(
+          f"Backend '{REDIS_AGENT_MEMORY_BACKEND}' requires "
+          f"{' and '.join(missing)}. Set them in your .env. See the managed "
+          "memory setup guide for where to obtain these values."
+      )
+  return api_key, store_id
+
+
 def redis_session_factory(uri: str, **kwargs):
   """Factory function for creating RedisWorkingMemorySessionService from URI."""
   base_url = parse_base_url(uri)
+  backend = os.getenv("REDIS_MEMORY_BACKEND", OPENSOURCE_AGENT_MEMORY_BACKEND)
+  api_key, store_id = resolve_managed_credentials(backend)
   config = RedisWorkingMemorySessionServiceConfig(
-      backend=os.getenv(
-          "REDIS_MEMORY_BACKEND", OPENSOURCE_AGENT_MEMORY_BACKEND
-      ),
+      backend=backend,
       api_base_url=base_url,
-      api_key=get_managed_credential(
-          "REDIS_AGENT_MEMORY_API_KEY", "AGENT_MEMORY_API_KEY"
-      ),
-      store_id=get_managed_credential(
-          "REDIS_AGENT_MEMORY_STORE_ID", "AGENT_MEMORY_STORE_ID"
-      ),
+      api_key=api_key,
+      store_id=store_id,
       default_namespace=os.getenv("REDIS_MEMORY_NAMESPACE", "adk_agent_memory"),
       model_name=os.getenv("REDIS_MEMORY_MODEL_NAME", "gpt-4o"),
       context_window_max=int(os.getenv("REDIS_MEMORY_CONTEXT_WINDOW", "8000")),
@@ -97,17 +132,13 @@ def redis_session_factory(uri: str, **kwargs):
 def redis_memory_factory(uri: str, **kwargs):
   """Factory function for creating RedisLongTermMemoryService from URI."""
   base_url = parse_base_url(uri)
+  backend = os.getenv("REDIS_MEMORY_BACKEND", OPENSOURCE_AGENT_MEMORY_BACKEND)
+  api_key, store_id = resolve_managed_credentials(backend)
   config = RedisLongTermMemoryServiceConfig(
-      backend=os.getenv(
-          "REDIS_MEMORY_BACKEND", OPENSOURCE_AGENT_MEMORY_BACKEND
-      ),
+      backend=backend,
       api_base_url=base_url,
-      api_key=get_managed_credential(
-          "REDIS_AGENT_MEMORY_API_KEY", "AGENT_MEMORY_API_KEY"
-      ),
-      store_id=get_managed_credential(
-          "REDIS_AGENT_MEMORY_STORE_ID", "AGENT_MEMORY_STORE_ID"
-      ),
+      api_key=api_key,
+      store_id=store_id,
       default_namespace=os.getenv("REDIS_MEMORY_NAMESPACE", "adk_agent_memory"),
       extraction_strategy=os.getenv(
           "REDIS_MEMORY_EXTRACTION_STRATEGY", "discrete"


### PR DESCRIPTION
## Summary

Completes the `[0.0.7]` changelog so it reflects everything that landed after the original 0.0.7 bump but before release. `pyproject.toml` is already at `0.0.7`; no version change needed.

## Added to the 0.0.7 entry
- Public backend selectors (`REDIS_AGENT_MEMORY_BACKEND`, `OPENSOURCE_AGENT_MEMORY_BACKEND`, `MemoryBackendName`) re-exported from `adk_redis` / `adk_redis.memory` (#17).
- `managed_memory_quickstart` example.
- **Fixed**: `UpdateMemoryTool` config-default application; events memory-ID collision fix; managed-backend session/namespace ID sanitization (#17 + earlier).
- **Docs**: managed setup how-to, env-var reconciliation, README examples matrix + run instructions (#18).
- Bumped the entry date to 2026-06-18.

## Validation
- `make check`: pyink/isort, ruff, mypy (31 files), pytest (115 passed, 10 skipped).
- `uv build`: produces `adk_redis-0.0.7` wheel + sdist.

After merge, a published GitHub Release tagged `0.0.7` will trigger the PyPI publish workflow.
