### PR TITLE
refactor(sessions): rename to RedisSessionMemoryService (0.0.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.0.8] - 2026-06-24
+
+### Changed
+
+- Renamed `RedisWorkingMemorySessionService` to `RedisSessionMemoryService`
+  and `RedisWorkingMemorySessionServiceConfig` to
+  `RedisSessionMemoryServiceConfig`, aligning with the managed Redis Agent
+  Memory "session memory" terminology and ADK's `<Backend>SessionService`
+  convention. The module `adk_redis.sessions.working_memory` moved to
+  `adk_redis.sessions.session_memory`. Docs and examples now use the new
+  names.
+
+### Deprecated
+
+- `RedisWorkingMemorySessionService` and
+  `RedisWorkingMemorySessionServiceConfig` remain as deprecated aliases that
+  emit a `DeprecationWarning` and will be removed in 0.1.0. Switch to
+  `RedisSessionMemoryService` / `RedisSessionMemoryServiceConfig`.
+
 ## [0.0.7] - 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `RedisWorkingMemorySessionServiceConfig` remain as deprecated aliases that
   emit a `DeprecationWarning` and will be removed in 0.1.0. Switch to
   `RedisSessionMemoryService` / `RedisSessionMemoryServiceConfig`.
+- The old module path `adk_redis.sessions.working_memory` remains as a
+  compatibility shim that re-exports the classes and emits a
+  `DeprecationWarning` on import. It will be removed in 0.1.0. Import from
+  `adk_redis.sessions.session_memory` or the top-level `adk_redis` package.
 
 ## [0.0.7] - 2026-06-18
 

--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ from google.adk.runners import Runner
 from adk_redis import (
     RedisLongTermMemoryService,
     RedisLongTermMemoryServiceConfig,
-    RedisWorkingMemorySessionService,
-    RedisWorkingMemorySessionServiceConfig,
+    RedisSessionMemoryService,
+    RedisSessionMemoryServiceConfig,
 )
 
-session_service = RedisWorkingMemorySessionService(
-    config=RedisWorkingMemorySessionServiceConfig(
+session_service = RedisSessionMemoryService(
+    config=RedisSessionMemoryServiceConfig(
         backend="redis-agent-memory",
         api_base_url="http://localhost:8088",
         api_key="...",

--- a/SKILL.md
+++ b/SKILL.md
@@ -94,12 +94,12 @@ from google.adk.runners import Runner
 from adk_redis import (
     RedisLongTermMemoryService,
     RedisLongTermMemoryServiceConfig,
-    RedisWorkingMemorySessionService,
-    RedisWorkingMemorySessionServiceConfig,
+    RedisSessionMemoryService,
+    RedisSessionMemoryServiceConfig,
 )
 
-session_service = RedisWorkingMemorySessionService(
-    config=RedisWorkingMemorySessionServiceConfig(
+session_service = RedisSessionMemoryService(
+    config=RedisSessionMemoryServiceConfig(
         api_base_url="http://localhost:8000",
     ),
 )

--- a/docs/concepts/adk_overview.md
+++ b/docs/concepts/adk_overview.md
@@ -37,7 +37,7 @@ flowchart TD
 
 | ADK Interface | `adk-redis` implementation | Concept page |
 |---------------|---------------------------|-------------|
-| `BaseSessionService` | `RedisWorkingMemorySessionService` | [Sessions + Memory Services](sessions.md) |
+| `BaseSessionService` | `RedisSessionMemoryService` | [Sessions + Memory Services](sessions.md) |
 | `BaseMemoryService` | `RedisLongTermMemoryService` | [Sessions + Memory Services](sessions.md) |
 | `BaseTool` | Search tools (`RedisVectorSearchTool`, `RedisHybridSearchTool`, etc.) and memory tools (`SearchMemoryTool`, `CreateMemoryTool`, etc.) | [Search Tools](search.md), [Memory MCP + Tools](memory.md) |
 | Model callbacks | `LLMResponseCache` with `RedisVLCacheProvider` or `LangCacheProvider` | [Semantic Caching](caching.md) |

--- a/docs/concepts/sessions.md
+++ b/docs/concepts/sessions.md
@@ -1,6 +1,6 @@
 # Sessions + Memory with Services
 
-Use `RedisWorkingMemorySessionService` and `RedisLongTermMemoryService` when you want the ADK `Runner` to manage sessions and memory automatically. Plug them in and let the framework handle the rest.
+Use `RedisSessionMemoryService` and `RedisLongTermMemoryService` when you want the ADK `Runner` to manage sessions and memory automatically. Plug them in and let the framework handle the rest.
 
 ## Quick Reference
 
@@ -54,12 +54,12 @@ from google.adk.runners import Runner
 from adk_redis import (
     RedisLongTermMemoryService,
     RedisLongTermMemoryServiceConfig,
-    RedisWorkingMemorySessionService,
-    RedisWorkingMemorySessionServiceConfig,
+    RedisSessionMemoryService,
+    RedisSessionMemoryServiceConfig,
 )
 
-session_service = RedisWorkingMemorySessionService(
-    config=RedisWorkingMemorySessionServiceConfig(
+session_service = RedisSessionMemoryService(
+    config=RedisSessionMemoryServiceConfig(
         backend="redis-agent-memory",
         api_base_url="http://localhost:8000",
         api_key="...",
@@ -103,7 +103,7 @@ adk web .
 
 ## Configuration
 
-### Session Service (`RedisWorkingMemorySessionServiceConfig`)
+### Session Service (`RedisSessionMemoryServiceConfig`)
 
 | Option | Default | Description |
 |--------|---------|-------------|

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -11,7 +11,7 @@ directory and explains what it demonstrates.
 
 | Example | What it shows |
 |---------|---------------|
-| [**Simple Redis memory**](https://github.com/redis-developer/adk-redis/tree/main/examples/simple_redis_memory) | Minimal agent with `RedisWorkingMemorySessionService` and `RedisLongTermMemoryService`. |
+| [**Simple Redis memory**](https://github.com/redis-developer/adk-redis/tree/main/examples/simple_redis_memory) | Minimal agent with `RedisSessionMemoryService` and `RedisLongTermMemoryService`. |
 | [**Fitness coach (MCP)**](https://github.com/redis-developer/adk-redis/tree/main/examples/fitness_coach_mcp) | MCP-based memory with `McpToolset` and Agent Memory Server. |
 | [**Travel agent (hybrid)**](https://github.com/redis-developer/adk-redis/tree/main/examples/travel_agent_memory_hybrid) | Framework-managed sessions + memory with vector search over travel docs. |
 | [**Travel agent (tools)**](https://github.com/redis-developer/adk-redis/tree/main/examples/travel_agent_memory_tools) | Same travel agent using LLM-controlled memory tools instead of framework services. |

--- a/docs/for-ais-only/BUILD_AND_TEST.md
+++ b/docs/for-ais-only/BUILD_AND_TEST.md
@@ -46,7 +46,7 @@ should ship with tests in the matching subdirectory under `tests/`.
 ## Running a single test
 
 ```
-uv run pytest tests/sessions/test_working_memory.py::<test_name> -vv
+uv run pytest tests/sessions/test_session_memory.py::<test_name> -vv
 uv run pytest tests/tools/test_vector_search.py -vv
 ```
 

--- a/docs/for-ais-only/FAILURE_MODES.md
+++ b/docs/for-ais-only/FAILURE_MODES.md
@@ -13,7 +13,7 @@ service method, and any prompt fragments together.
 
 ## Sessions and memory go through Agent Memory Server, not Redis directly
 
-Both `RedisWorkingMemorySessionService` and `RedisLongTermMemoryService`
+Both `RedisSessionMemoryService` and `RedisLongTermMemoryService`
 talk to Agent Memory Server, not raw Redis. Reaching into Redis from
 either service bypasses dedup, summarization, embedding, and the
 working-to-long-term promotion pipeline. Stay on the AMS client.

--- a/docs/for-ais-only/REPOSITORY_MAP.md
+++ b/docs/for-ais-only/REPOSITORY_MAP.md
@@ -15,9 +15,9 @@ src/adk_redis/
                           session, search, tool, and cache classes).
   _version.py             Build-time version string.
   sessions/
-    __init__.py           Re-exports RedisWorkingMemorySessionService.
-    working_memory.py     ADK BaseSessionService implementation backed by
-                          Redis Agent Memory Server working memory.
+    __init__.py           Re-exports RedisSessionMemoryService.
+    session_memory.py     ADK BaseSessionService implementation backed by
+                          Redis Agent Memory or Agent Memory Server.
   memory/
     __init__.py           Re-exports RedisLongTermMemoryService and the
                           memory tools (Memory Prompt / Search / Create /
@@ -50,7 +50,7 @@ tests/
   test_imports.py              Smoke test for every public re-export.
   test_version.py              `__version__` is set.
   sessions/
-    test_working_memory.py     RedisWorkingMemorySessionService end-to-end.
+    test_session_memory.py     RedisSessionMemoryService end-to-end.
   memory/
     test_long_term_memory.py   RedisLongTermMemoryService end-to-end.
   tools/
@@ -77,7 +77,7 @@ tests/
 
 | Feature | Module(s) |
 |---|---|
-| Working-memory session storage | `sessions/working_memory.py` |
+| Session storage (session memory) | `sessions/session_memory.py` |
 | Long-term memory + Memory Server proxy | `memory/long_term_memory.py`, `memory/_utils.py` |
 | ADK Memory tools (FunctionTool wrappers) | `tools/memory/` |
 | MCP (RedisVL or AMS) | Use ADK's native `McpToolset` directly; no adk-redis wrapper. |
@@ -92,9 +92,10 @@ tests/
   `FunctionTool` plus a thin RedisVL query. Tools are independent; copy
   the closest existing one. Wire it through `tools/__init__.py` and the
   re-export in `adk_redis/__init__.py`.
-- **The session service.** `sessions/working_memory.py` implements ADK's
-  `BaseSessionService`. It calls Agent Memory Server working-memory
-  endpoints; do not reach into Redis directly from the session layer.
+- **The session service.** `sessions/session_memory.py` implements ADK's
+  `BaseSessionService`. It calls the configured memory backend (Redis Agent
+  Memory or the self-hosted Agent Memory Server working-memory endpoints); do
+  not reach into Redis directly from the session layer.
 - **The memory service.** `memory/long_term_memory.py` implements ADK's
   `BaseMemoryService`. The memory tools under `tools/memory/` are thin
   `FunctionTool` wrappers and must keep parameter names aligned with

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -28,14 +28,14 @@ For task-oriented recipes, browse the
 - [Redis setup](user_guide/how_to_guides/redis_setup.md): start Redis 8.4 locally or in Redis Cloud.
 - [Managed memory setup](user_guide/how_to_guides/managed_memory_setup.md): connect to the managed Redis Agent Memory backend.
 - [Memory server setup](user_guide/how_to_guides/memory_server_setup.md): run Agent Memory Server.
-- [Session service](user_guide/how_to_guides/session_service.md): wire `RedisWorkingMemorySessionService`.
+- [Session service](user_guide/how_to_guides/session_service.md): wire `RedisSessionMemoryService`.
 - [Memory service](user_guide/how_to_guides/memory_service.md): wire `RedisLongTermMemoryService`.
 - [Search tools](user_guide/how_to_guides/search_tools.md): use the five search tools and the RedisVL MCP toolset.
 - [Semantic cache](user_guide/how_to_guides/semantic_cache.md): add self-hosted or managed semantic caching.
 
 ## API reference
 
-- [Sessions](api/python/sessions.md): `RedisWorkingMemorySessionService`, `RedisWorkingMemorySessionServiceConfig`.
+- [Sessions](api/python/sessions.md): `RedisSessionMemoryService`, `RedisSessionMemoryServiceConfig`.
 - [Memory](api/python/memory.md): `RedisLongTermMemoryService`, `RedisLongTermMemoryServiceConfig`.
 - [Tools](api/python/tools.md): search tools, memory tools, MCP toolset helpers.
 - [Cache](api/python/cache.md): cache providers, `LLMResponseCache`, `ToolCache`, callback factories.

--- a/docs/specs/examples-memory-coverage-handover.md
+++ b/docs/specs/examples-memory-coverage-handover.md
@@ -38,7 +38,7 @@ end-to-end against `redis-agent-memory`, and if not, what is missing?"
 
 1. Read the current backend dispatch:
    - `src/adk_redis/memory/long_term_memory.py`
-   - `src/adk_redis/sessions/working_memory.py`
+   - `src/adk_redis/sessions/session_memory.py`
    - `src/adk_redis/tools/memory/` (all six tools plus `_base.py` and
      `_config.py`)
    - `src/adk_redis/memory/_backends.py`
@@ -52,7 +52,7 @@ end-to-end against `redis-agent-memory`, and if not, what is missing?"
 4. For each ADK surface we expose
    (`RedisLongTermMemoryService.add_session_to_memory` / `add_memory` /
    `add_events_to_memory` / `search_memory`,
-   `RedisWorkingMemorySessionService.create_session` / `get_session` /
+   `RedisSessionMemoryService.create_session` / `get_session` /
    `list_sessions` / `append_event` / `delete_session`, and each memory
    tool), record:
    - Does the managed SDK have a primitive we can call?
@@ -79,7 +79,7 @@ are different depending on whether managed has full parity, partial
 parity, or a known feature gap.
 
 1. Enumerate the current examples and what each one actually exercises:
-   - Which use `RedisLongTermMemoryService` / `RedisWorkingMemorySessionService`?
+   - Which use `RedisLongTermMemoryService` / `RedisSessionMemoryService`?
    - Which use the memory tools directly?
    - Which use the Agent Memory Server MCP endpoint?
    - Which use the `adk web` runner vs. a custom `main.py` via
@@ -151,7 +151,7 @@ current server image.
   `context_window_max` using the configured `model_name`. The managed
   docs do not describe an equivalent. Confirm whether the managed
   session-memory endpoint has any size-based behavior, and document any
-  `RedisWorkingMemorySessionServiceConfig` fields that become no-ops on
+  `RedisSessionMemoryServiceConfig` fields that become no-ops on
   managed.
 - **Recency-boosted search is opensource only (as documented).**
   Opensource search exposes `semantic_weight` / `recency_weight` /
@@ -219,7 +219,7 @@ current server image.
 - Backend selection spec: [`redis-agent-memory-default.md`](redis-agent-memory-default.md)
 - Backend dispatch:
   - `src/adk_redis/memory/long_term_memory.py`
-  - `src/adk_redis/sessions/working_memory.py`
+  - `src/adk_redis/sessions/session_memory.py`
   - `src/adk_redis/tools/memory/_config.py`
   - `src/adk_redis/tools/memory/_base.py`
 - Live integration coverage: `tests/integration/test_memory_backends_end_to_end.py`

--- a/docs/specs/redis-agent-memory-default.md
+++ b/docs/specs/redis-agent-memory-default.md
@@ -17,7 +17,7 @@ backend="opensource-agent-memory"  # self-hosted, uses agent-memory-client
 
 The public class names stay unchanged:
 
-- `RedisWorkingMemorySessionService`
+- `RedisSessionMemoryService`
 - `RedisLongTermMemoryService`
 - `MemoryToolConfig`
 - `SearchMemoryTool`, `CreateMemoryTool`, `GetMemoryTool`,

--- a/docs/user_guide/01_integration.md
+++ b/docs/user_guide/01_integration.md
@@ -42,8 +42,8 @@ from google.adk.tools import load_memory
 from google.adk.tools import preload_memory
 from adk_redis import (
     REDIS_AGENT_MEMORY_BACKEND,
-    RedisWorkingMemorySessionService,
-    RedisWorkingMemorySessionServiceConfig,
+    RedisSessionMemoryService,
+    RedisSessionMemoryServiceConfig,
     RedisLongTermMemoryService,
     RedisLongTermMemoryServiceConfig,
 )
@@ -52,8 +52,8 @@ from adk_redis import (
 # aliases for the "redis-agent-memory" and "opensource-agent-memory" strings.
 backend = os.getenv("REDIS_MEMORY_BACKEND", REDIS_AGENT_MEMORY_BACKEND)
 
-session_service = RedisWorkingMemorySessionService(
-    config=RedisWorkingMemorySessionServiceConfig(
+session_service = RedisSessionMemoryService(
+    config=RedisSessionMemoryServiceConfig(
         backend=backend,
         api_base_url=os.environ["REDIS_AGENT_MEMORY_API_BASE_URL"],
         api_key=os.environ.get("REDIS_AGENT_MEMORY_API_KEY"),

--- a/docs/user_guide/how_to_guides/managed_memory_setup.md
+++ b/docs/user_guide/how_to_guides/managed_memory_setup.md
@@ -64,12 +64,12 @@ from adk_redis import (
     REDIS_AGENT_MEMORY_BACKEND,
     RedisLongTermMemoryService,
     RedisLongTermMemoryServiceConfig,
-    RedisWorkingMemorySessionService,
-    RedisWorkingMemorySessionServiceConfig,
+    RedisSessionMemoryService,
+    RedisSessionMemoryServiceConfig,
 )
 
-session_service = RedisWorkingMemorySessionService(
-    config=RedisWorkingMemorySessionServiceConfig(
+session_service = RedisSessionMemoryService(
+    config=RedisSessionMemoryServiceConfig(
         backend=REDIS_AGENT_MEMORY_BACKEND,
         api_base_url=os.environ["REDIS_AGENT_MEMORY_API_BASE_URL"],
         api_key=os.environ["REDIS_AGENT_MEMORY_API_KEY"],

--- a/docs/user_guide/how_to_guides/memory_service.md
+++ b/docs/user_guide/how_to_guides/memory_service.md
@@ -21,12 +21,12 @@ from google.adk.runners import Runner
 from adk_redis import (
     RedisLongTermMemoryService,
     RedisLongTermMemoryServiceConfig,
-    RedisWorkingMemorySessionService,
-    RedisWorkingMemorySessionServiceConfig,
+    RedisSessionMemoryService,
+    RedisSessionMemoryServiceConfig,
 )
 
-session_service = RedisWorkingMemorySessionService(
-    config=RedisWorkingMemorySessionServiceConfig(
+session_service = RedisSessionMemoryService(
+    config=RedisSessionMemoryServiceConfig(
         backend="redis-agent-memory",
         api_base_url="http://localhost:8000",
         api_key="...",

--- a/docs/user_guide/how_to_guides/redis_setup.md
+++ b/docs/user_guide/how_to_guides/redis_setup.md
@@ -42,7 +42,7 @@ docker rm redis
 
 ### Option 2: Redis Agent Memory Server (Docker)
 
-**Use case:** Memory and session services (RedisLongTermMemoryService, RedisWorkingMemorySessionService)
+**Use case:** Memory and session services (RedisLongTermMemoryService, RedisSessionMemoryService)
 
 **Features:**
 - Two-tier memory architecture (working + long-term)

--- a/docs/user_guide/how_to_guides/session_service.md
+++ b/docs/user_guide/how_to_guides/session_service.md
@@ -1,6 +1,6 @@
 # Session Service
 
-This guide shows how to wire `RedisWorkingMemorySessionService` into a Google
+This guide shows how to wire `RedisSessionMemoryService` into a Google
 ADK agent for durable session state backed by Redis Agent Memory session
 events or self-hosted Agent Memory Server working memory.
 
@@ -19,12 +19,12 @@ For the concepts behind sessions and working memory, see
 from google.adk import Agent
 from google.adk.runners import Runner
 from adk_redis import (
-    RedisWorkingMemorySessionService,
-    RedisWorkingMemorySessionServiceConfig,
+    RedisSessionMemoryService,
+    RedisSessionMemoryServiceConfig,
 )
 
-session_service = RedisWorkingMemorySessionService(
-    config=RedisWorkingMemorySessionServiceConfig(
+session_service = RedisSessionMemoryService(
+    config=RedisSessionMemoryServiceConfig(
         backend="redis-agent-memory",
         api_base_url="http://localhost:8000",
         api_key="...",

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,7 +15,7 @@ and `adk-redis`. Each example ships with a README and `.env.example`.
 
 ### Runner notes
 
-- **`python main.py`** — Required when registering `RedisWorkingMemorySessionService`
+- **`python main.py`** — Required when registering `RedisSessionMemoryService`
   and/or `RedisLongTermMemoryService` through `get_service_registry()`. ADK's
   `get_fast_api_app` reads those registrations; `adk web` does not.
 - **`adk web .`** — Works when memory is wired as agent tools in `agent.py`

--- a/examples/managed_memory_quickstart/README.md
+++ b/examples/managed_memory_quickstart/README.md
@@ -6,7 +6,7 @@ with no self-hosted Agent Memory Server or Docker setup.
 
 ## What it demonstrates
 
-- `RedisWorkingMemorySessionService` for session persistence
+- `RedisSessionMemoryService` for session persistence
 - `RedisLongTermMemoryService` for semantic memory search
 - ADK built-in `preload_memory` and `load_memory` tools
 

--- a/examples/managed_memory_quickstart/main.py
+++ b/examples/managed_memory_quickstart/main.py
@@ -14,7 +14,7 @@
 
 """Managed Redis Agent Memory quickstart.
 
-Registers RedisWorkingMemorySessionService and RedisLongTermMemoryService
+Registers RedisSessionMemoryService and RedisLongTermMemoryService
 against the managed redis-agent-memory backend, then serves the agent via ADK's
 FastAPI runner.
 """
@@ -31,8 +31,8 @@ import uvicorn
 from adk_redis import REDIS_AGENT_MEMORY_BACKEND
 from adk_redis.memory import RedisLongTermMemoryService
 from adk_redis.memory import RedisLongTermMemoryServiceConfig
-from adk_redis.sessions import RedisWorkingMemorySessionService
-from adk_redis.sessions import RedisWorkingMemorySessionServiceConfig
+from adk_redis.sessions import RedisSessionMemoryService
+from adk_redis.sessions import RedisSessionMemoryServiceConfig
 
 load_dotenv()
 
@@ -55,9 +55,9 @@ def parse_base_url(uri: str) -> str:
 
 
 def redis_session_factory(uri: str, **kwargs):
-  """Factory for RedisWorkingMemorySessionService."""
+  """Factory for RedisSessionMemoryService."""
   base_url = parse_base_url(uri)
-  config = RedisWorkingMemorySessionServiceConfig(
+  config = RedisSessionMemoryServiceConfig(
       backend=_BACKEND,
       api_base_url=base_url,
       api_key=os.environ["REDIS_AGENT_MEMORY_API_KEY"],
@@ -66,7 +66,7 @@ def redis_session_factory(uri: str, **kwargs):
           "REDIS_MEMORY_NAMESPACE", "managed_memory_quickstart"
       ),
   )
-  return RedisWorkingMemorySessionService(config=config)
+  return RedisSessionMemoryService(config=config)
 
 
 def redis_memory_factory(uri: str, **kwargs):
@@ -117,7 +117,7 @@ Store ID:       {os.environ["REDIS_AGENT_MEMORY_STORE_ID"]}
 Namespace:      {namespace}
 
 Services:
-  - Session: RedisWorkingMemorySessionService
+  - Session: RedisSessionMemoryService
   - Memory:  RedisLongTermMemoryService
 """
   )

--- a/examples/simple_redis_memory/README.md
+++ b/examples/simple_redis_memory/README.md
@@ -2,7 +2,7 @@
 
 This sample demonstrates the **complete two-tier memory architecture** using Redis Agent Memory Server with the `adk-redis` package:
 
-1. **RedisWorkingMemorySessionService** - Session management with auto-summarization
+1. **RedisSessionMemoryService** - Session management with auto-summarization
 2. **RedisLongTermMemoryService** - Persistent long-term memory with semantic search
 
 ## Architecture

--- a/examples/simple_redis_memory/main.py
+++ b/examples/simple_redis_memory/main.py
@@ -15,7 +15,7 @@
 """Redis Memory Sample: Working Memory Sessions + Long-Term Memory.
 
 This sample demonstrates using BOTH Redis Agent Memory Server services:
-1. RedisWorkingMemorySessionService - For session management with auto-summarization
+1. RedisSessionMemoryService - For session management with auto-summarization
 2. RedisLongTermMemoryService - For persistent long-term memory search
 
 This provides the complete two-tier memory architecture:
@@ -36,8 +36,8 @@ from adk_redis import OPENSOURCE_AGENT_MEMORY_BACKEND
 from adk_redis import REDIS_AGENT_MEMORY_BACKEND
 from adk_redis.memory import RedisLongTermMemoryService
 from adk_redis.memory import RedisLongTermMemoryServiceConfig
-from adk_redis.sessions import RedisWorkingMemorySessionService
-from adk_redis.sessions import RedisWorkingMemorySessionServiceConfig
+from adk_redis.sessions import RedisSessionMemoryService
+from adk_redis.sessions import RedisSessionMemoryServiceConfig
 
 load_dotenv()
 
@@ -110,11 +110,11 @@ def resolve_managed_credentials(backend: str) -> tuple[str | None, str | None]:
 
 
 def redis_session_factory(uri: str, **kwargs):
-  """Factory function for creating RedisWorkingMemorySessionService from URI."""
+  """Factory function for creating RedisSessionMemoryService from URI."""
   base_url = parse_base_url(uri)
   backend = os.getenv("REDIS_MEMORY_BACKEND", OPENSOURCE_AGENT_MEMORY_BACKEND)
   api_key, store_id = resolve_managed_credentials(backend)
-  config = RedisWorkingMemorySessionServiceConfig(
+  config = RedisSessionMemoryServiceConfig(
       backend=backend,
       api_base_url=base_url,
       api_key=api_key,
@@ -126,7 +126,7 @@ def redis_session_factory(uri: str, **kwargs):
           "REDIS_MEMORY_EXTRACTION_STRATEGY", "discrete"
       ),
   )
-  return RedisWorkingMemorySessionService(config=config)
+  return RedisSessionMemoryService(config=config)
 
 
 def redis_memory_factory(uri: str, **kwargs):
@@ -194,7 +194,7 @@ Extraction Strategy: {extraction}
 Context Window:      {context_window} tokens
 
 Services:
-  - Session:  RedisWorkingMemorySessionService (auto-summarization)
+  - Session:  RedisSessionMemoryService (auto-summarization)
   - Memory:   RedisLongTermMemoryService (semantic search)
 
 Two-Tier Architecture:

--- a/examples/travel_agent_memory_hybrid/README.md
+++ b/examples/travel_agent_memory_hybrid/README.md
@@ -26,7 +26,7 @@ uv run python main.py
 This example showcases the full hybrid integration combining:
 
 **Framework-Managed Services (via main.py):**
-- **RedisWorkingMemorySessionService** - Session persistence with auto-summarization
+- **RedisSessionMemoryService** - Session persistence with auto-summarization
 - **RedisLongTermMemoryService** - Automatic memory extraction and semantic search
 
 **LLM-Controlled Tools:**
@@ -144,7 +144,7 @@ Then open **http://localhost:8080** in your browser.
 - Hot reload on code changes
 
 **What's Different from `travel_agent_memory`:**
-- Uses `RedisWorkingMemorySessionService` for session persistence
+- Uses `RedisSessionMemoryService` for session persistence
 - Uses `RedisLongTermMemoryService` for automatic memory extraction
 - PLUS all the memory tools for explicit LLM control
 
@@ -153,10 +153,10 @@ Then open **http://localhost:8080** in your browser.
 ```python
 from travel_agent import root_agent
 from google.adk.runners import Runner
-from adk_redis.sessions import RedisWorkingMemorySessionService
+from adk_redis.sessions import RedisSessionMemoryService
 from adk_redis.memory import RedisLongTermMemoryService
 
-session_service = RedisWorkingMemorySessionService()
+session_service = RedisSessionMemoryService()
 memory_service = RedisLongTermMemoryService()
 
 runner = Runner(

--- a/examples/travel_agent_memory_hybrid/main.py
+++ b/examples/travel_agent_memory_hybrid/main.py
@@ -15,7 +15,7 @@
 """Travel Agent Hybrid: Full Session + Memory Services with Memory Tools.
 
 This example demonstrates the HYBRID approach combining:
-1. RedisWorkingMemorySessionService - For session management with auto-summarization
+1. RedisSessionMemoryService - For session management with auto-summarization
 2. RedisLongTermMemoryService - For persistent long-term memory search
 3. Memory Tools - For explicit LLM-controlled memory operations
 
@@ -36,8 +36,8 @@ import uvicorn
 from adk_redis import OPENSOURCE_AGENT_MEMORY_BACKEND
 from adk_redis.memory import RedisLongTermMemoryService
 from adk_redis.memory import RedisLongTermMemoryServiceConfig
-from adk_redis.sessions import RedisWorkingMemorySessionService
-from adk_redis.sessions import RedisWorkingMemorySessionServiceConfig
+from adk_redis.sessions import RedisSessionMemoryService
+from adk_redis.sessions import RedisSessionMemoryServiceConfig
 
 load_dotenv()
 
@@ -54,9 +54,9 @@ def parse_base_url(uri: str) -> str:
 
 
 def redis_session_factory(uri: str, **kwargs):
-  """Factory function for creating RedisWorkingMemorySessionService from URI."""
+  """Factory function for creating RedisSessionMemoryService from URI."""
   base_url = parse_base_url(uri)
-  config = RedisWorkingMemorySessionServiceConfig(
+  config = RedisSessionMemoryServiceConfig(
       backend=os.getenv(
           "REDIS_MEMORY_BACKEND", OPENSOURCE_AGENT_MEMORY_BACKEND
       ),
@@ -70,7 +70,7 @@ def redis_session_factory(uri: str, **kwargs):
           "REDIS_MEMORY_EXTRACTION_STRATEGY", "discrete"
       ),
   )
-  return RedisWorkingMemorySessionService(config=config)
+  return RedisSessionMemoryService(config=config)
 
 
 def redis_memory_factory(uri: str, **kwargs):
@@ -138,7 +138,7 @@ Extraction Strategy: {extraction}
 Context Window:      {context_window} tokens
 
 Services (Framework-Managed):
-  - Session:  RedisWorkingMemorySessionService (auto-summarization)
+  - Session:  RedisSessionMemoryService (auto-summarization)
   - Memory:   RedisLongTermMemoryService (semantic search)
 
 Tools (LLM-Controlled):

--- a/examples/travel_agent_memory_hybrid/travel_agent/__init__.py
+++ b/examples/travel_agent_memory_hybrid/travel_agent/__init__.py
@@ -18,7 +18,7 @@ This package provides a comprehensive travel planning agent demonstrating
 the HYBRID approach with both framework-managed services and LLM-controlled tools:
 
 Framework-Managed (via main.py):
-- RedisWorkingMemorySessionService (auto-summarization)
+- RedisSessionMemoryService (auto-summarization)
 - RedisLongTermMemoryService (semantic search)
 
 LLM-Controlled (via tools):

--- a/examples/travel_agent_memory_hybrid/travel_agent/agent.py
+++ b/examples/travel_agent_memory_hybrid/travel_agent/agent.py
@@ -17,7 +17,7 @@
 This agent demonstrates the HYBRID approach combining:
 
 Framework-Managed (via main.py services):
-- RedisWorkingMemorySessionService - Session persistence with auto-summarization
+- RedisSessionMemoryService - Session persistence with auto-summarization
 - RedisLongTermMemoryService - Automatic memory extraction and semantic search
 
 LLM-Controlled (via tools):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "adk-redis"
-version = "0.0.7"
+version = "0.0.8"
 description = "Redis integrations for Google's Agent Development Kit (ADK)"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/adk_redis/__init__.py
+++ b/src/adk_redis/__init__.py
@@ -20,7 +20,7 @@ Memory Services:
     - RedisLongTermMemoryService: Long-term memory with semantic search
 
 Session Services:
-    - RedisWorkingMemorySessionService: Session management with working memory
+    - RedisSessionMemoryService: Session management backed by session memory
 
 Search Tools:
     - RedisVectorSearchTool: Vector similarity search
@@ -48,8 +48,8 @@ Example:
     from adk_redis import (
         RedisLongTermMemoryService,
         RedisLongTermMemoryServiceConfig,
-        RedisWorkingMemorySessionService,
-        RedisWorkingMemorySessionServiceConfig,
+        RedisSessionMemoryService,
+        RedisSessionMemoryServiceConfig,
     )
 
     # Configure memory service
@@ -62,13 +62,13 @@ Example:
     memory_service = RedisLongTermMemoryService(config=memory_config)
 
     # Configure session service
-    session_config = RedisWorkingMemorySessionServiceConfig(
+    session_config = RedisSessionMemoryServiceConfig(
         backend="redis-agent-memory",
         api_base_url="http://localhost:8000",
         api_key="...",
         store_id="...",
     )
-    session_service = RedisWorkingMemorySessionService(config=session_config)
+    session_service = RedisSessionMemoryService(config=session_config)
     ```
 """
 
@@ -81,6 +81,8 @@ from adk_redis.memory import MemoryBackendName
 from adk_redis.memory import RedisLongTermMemoryService
 from adk_redis.memory import RedisLongTermMemoryServiceConfig
 # Session services
+from adk_redis.sessions import RedisSessionMemoryService
+from adk_redis.sessions import RedisSessionMemoryServiceConfig
 from adk_redis.sessions import RedisWorkingMemorySessionService
 from adk_redis.sessions import RedisWorkingMemorySessionServiceConfig
 # Search tools - import from tools submodule
@@ -129,6 +131,9 @@ __all__ = [
     "RedisLongTermMemoryService",
     "RedisLongTermMemoryServiceConfig",
     # Session services
+    "RedisSessionMemoryService",
+    "RedisSessionMemoryServiceConfig",
+    # Deprecated session-service aliases, removed in 0.1.0.
     "RedisWorkingMemorySessionService",
     "RedisWorkingMemorySessionServiceConfig",
     # Search tools - base classes

--- a/src/adk_redis/sessions/__init__.py
+++ b/src/adk_redis/sessions/__init__.py
@@ -14,10 +14,17 @@
 
 """Redis session services for ADK."""
 
-from adk_redis.sessions.working_memory import RedisWorkingMemorySessionService
-from adk_redis.sessions.working_memory import RedisWorkingMemorySessionServiceConfig
+from adk_redis.sessions.session_memory import RedisSessionMemoryService
+from adk_redis.sessions.session_memory import RedisSessionMemoryServiceConfig
+from adk_redis.sessions.session_memory import RedisWorkingMemorySessionService
+from adk_redis.sessions.session_memory import (
+    RedisWorkingMemorySessionServiceConfig,
+)
 
 __all__ = [
+    "RedisSessionMemoryService",
+    "RedisSessionMemoryServiceConfig",
+    # Deprecated aliases, removed in 0.1.0.
     "RedisWorkingMemorySessionService",
     "RedisWorkingMemorySessionServiceConfig",
 ]

--- a/src/adk_redis/sessions/session_memory.py
+++ b/src/adk_redis/sessions/session_memory.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Redis working memory session service for ADK."""
+"""Redis session memory service for ADK."""
 
 from __future__ import annotations
 
@@ -24,6 +24,7 @@ import logging
 import time
 from typing import Any, AsyncIterator, Literal
 import uuid
+import warnings
 
 from google.adk.events.event import Event
 from google.adk.sessions.base_session_service import BaseSessionService
@@ -80,8 +81,8 @@ else:
   _AgentMemory = _redis_agent_memory_module.AgentMemory
 
 
-class RedisWorkingMemorySessionServiceConfig(BaseModel):
-  """Configuration for Redis working memory session service.
+class RedisSessionMemoryServiceConfig(BaseModel):
+  """Configuration for Redis session memory service.
 
   Attributes:
       backend: Memory backend to use.
@@ -118,7 +119,7 @@ class RedisWorkingMemorySessionServiceConfig(BaseModel):
   session_ttl_seconds: int | None = Field(default=None, ge=1)
 
 
-class RedisWorkingMemorySessionService(BaseSessionService):
+class RedisSessionMemoryService(BaseSessionService):
   """Session service backed by Redis memory backends.
 
   Redis Agent Memory stores session events by session ID. The self-hosted
@@ -126,15 +127,13 @@ class RedisWorkingMemorySessionService(BaseSessionService):
   sessions keep the original caller-facing session ID for both backends.
   """
 
-  def __init__(
-      self, config: RedisWorkingMemorySessionServiceConfig | None = None
-  ):
+  def __init__(self, config: RedisSessionMemoryServiceConfig | None = None):
     """Initialize the Redis Agent Memory session service.
 
     Args:
         config: Configuration for the service. If None, defaults are used.
     """
-    self._config = config or RedisWorkingMemorySessionServiceConfig()
+    self._config = config or RedisSessionMemoryServiceConfig()
 
   def _timeout_ms(self) -> int:
     """Return the configured SDK timeout in milliseconds."""
@@ -151,7 +150,7 @@ class RedisWorkingMemorySessionService(BaseSessionService):
     if _AgentMemory is None:
       raise ImportError(
           "redis-agent-memory package is required for "
-          "RedisWorkingMemorySessionService. "
+          "RedisSessionMemoryService. "
           "Install it with: pip install adk-redis[memory]"
       )
 
@@ -472,9 +471,7 @@ class RedisWorkingMemorySessionService(BaseSessionService):
   ) -> ListSessionsResponse:
     """List sessions from the self-hosted Agent Memory Server."""
     if user_id is None:
-      raise ValueError(
-          "user_id is required for RedisWorkingMemorySessionService"
-      )
+      raise ValueError("user_id is required for RedisSessionMemoryService")
 
     try:
       namespace = self._get_namespace(app_name)
@@ -833,3 +830,35 @@ class RedisWorkingMemorySessionService(BaseSessionService):
   async def close(self) -> None:
     """Close the session service and cleanup resources."""
     pass
+
+
+class RedisWorkingMemorySessionServiceConfig(RedisSessionMemoryServiceConfig):
+  """Deprecated alias for :class:`RedisSessionMemoryServiceConfig`.
+
+  Retained for backward compatibility and removed in 0.1.0.
+  """
+
+  def __init__(self, **data: Any):
+    warnings.warn(
+        "RedisWorkingMemorySessionServiceConfig is deprecated; use "
+        "RedisSessionMemoryServiceConfig. The alias will be removed in 0.1.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    super().__init__(**data)
+
+
+class RedisWorkingMemorySessionService(RedisSessionMemoryService):
+  """Deprecated alias for :class:`RedisSessionMemoryService`.
+
+  Retained for backward compatibility and removed in 0.1.0.
+  """
+
+  def __init__(self, config: RedisSessionMemoryServiceConfig | None = None):
+    warnings.warn(
+        "RedisWorkingMemorySessionService is deprecated; use "
+        "RedisSessionMemoryService. The alias will be removed in 0.1.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    super().__init__(config=config)

--- a/src/adk_redis/sessions/working_memory.py
+++ b/src/adk_redis/sessions/working_memory.py
@@ -1,0 +1,47 @@
+# Copyright 2025 Redis, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deprecated module path for the Redis session memory service.
+
+This module was renamed to :mod:`adk_redis.sessions.session_memory`. It is
+retained as a compatibility shim that re-exports the public classes and will
+be removed in 0.1.0. Import from ``adk_redis.sessions.session_memory`` or the
+top-level ``adk_redis`` package instead.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+from adk_redis.sessions.session_memory import RedisSessionMemoryService
+from adk_redis.sessions.session_memory import RedisSessionMemoryServiceConfig
+from adk_redis.sessions.session_memory import RedisWorkingMemorySessionService
+from adk_redis.sessions.session_memory import (
+    RedisWorkingMemorySessionServiceConfig,
+)
+
+warnings.warn(
+    "adk_redis.sessions.working_memory is deprecated; import from "
+    "adk_redis.sessions.session_memory (or adk_redis). This module path will "
+    "be removed in 0.1.0.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+__all__ = [
+    "RedisSessionMemoryService",
+    "RedisSessionMemoryServiceConfig",
+    "RedisWorkingMemorySessionService",
+    "RedisWorkingMemorySessionServiceConfig",
+]

--- a/tests/integration/test_memory_backends_end_to_end.py
+++ b/tests/integration/test_memory_backends_end_to_end.py
@@ -14,7 +14,7 @@
 
 """End-to-end integration tests for the selectable memory backends.
 
-Round-trips RedisLongTermMemoryService and RedisWorkingMemorySessionService
+Round-trips RedisLongTermMemoryService and RedisSessionMemoryService
 against real backends. Tests skip when env vars are not set:
 
 - redis-agent-memory (managed): REDIS_AGENT_MEMORY_API_BASE_URL,
@@ -35,8 +35,8 @@ from adk_redis import OPENSOURCE_AGENT_MEMORY_BACKEND
 from adk_redis import REDIS_AGENT_MEMORY_BACKEND
 from adk_redis import RedisLongTermMemoryService
 from adk_redis import RedisLongTermMemoryServiceConfig
-from adk_redis import RedisWorkingMemorySessionService
-from adk_redis import RedisWorkingMemorySessionServiceConfig
+from adk_redis import RedisSessionMemoryService
+from adk_redis import RedisSessionMemoryServiceConfig
 from tests.integration.conftest import AGENT_MEMORY_SERVER_URL
 from tests.integration.conftest import REDIS_AGENT_MEMORY_API_KEY
 from tests.integration.conftest import REDIS_AGENT_MEMORY_STORE_ID
@@ -105,8 +105,8 @@ class TestRedisAgentMemoryBackendEndToEnd:
   async def test_session_append_and_get(
       self, unique_namespace: str, unique_user_id: str
   ) -> None:
-    sessions = RedisWorkingMemorySessionService(
-        config=RedisWorkingMemorySessionServiceConfig(
+    sessions = RedisSessionMemoryService(
+        config=RedisSessionMemoryServiceConfig(
             backend=REDIS_AGENT_MEMORY_BACKEND,
             api_base_url=REDIS_AGENT_MEMORY_URL,
             api_key=REDIS_AGENT_MEMORY_API_KEY,

--- a/tests/sessions/test_session_memory.py
+++ b/tests/sessions/test_session_memory.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for RedisWorkingMemorySessionService."""
+"""Tests for RedisSessionMemoryService."""
 
 from datetime import datetime
 from datetime import timezone
@@ -26,8 +26,8 @@ import pytest
 
 from adk_redis import OPENSOURCE_AGENT_MEMORY_BACKEND
 from adk_redis import REDIS_AGENT_MEMORY_BACKEND
-from adk_redis.sessions import RedisWorkingMemorySessionService
-from adk_redis.sessions import RedisWorkingMemorySessionServiceConfig
+from adk_redis.sessions import RedisSessionMemoryService
+from adk_redis.sessions import RedisSessionMemoryServiceConfig
 
 
 class FakeAgentMemory:
@@ -75,12 +75,12 @@ class FakeAgentMemoryServerClient:
     return self.list_response
 
 
-class TestRedisWorkingMemorySessionServiceConfig:
-  """Tests for RedisWorkingMemorySessionServiceConfig."""
+class TestRedisSessionMemoryServiceConfig:
+  """Tests for RedisSessionMemoryServiceConfig."""
 
   def test_default_values(self):
     """Test default configuration values."""
-    config = RedisWorkingMemorySessionServiceConfig()
+    config = RedisSessionMemoryServiceConfig()
     assert config.backend == REDIS_AGENT_MEMORY_BACKEND
     assert config.api_base_url == "http://localhost:8000"
     assert config.api_key is None
@@ -95,7 +95,7 @@ class TestRedisWorkingMemorySessionServiceConfig:
 
   def test_custom_values(self):
     """Test custom configuration values."""
-    config = RedisWorkingMemorySessionServiceConfig(
+    config = RedisSessionMemoryServiceConfig(
         api_base_url="http://custom:9000",
         api_key="key",
         store_id="store",
@@ -118,31 +118,31 @@ class TestRedisWorkingMemorySessionServiceConfig:
 
   def test_opensource_backend_value(self):
     """Test the self-hosted backend value is accepted."""
-    config = RedisWorkingMemorySessionServiceConfig(
+    config = RedisSessionMemoryServiceConfig(
         backend=OPENSOURCE_AGENT_MEMORY_BACKEND
     )
     assert config.backend == OPENSOURCE_AGENT_MEMORY_BACKEND
 
 
-class TestRedisWorkingMemorySessionServiceInit:
-  """Tests for RedisWorkingMemorySessionService initialization."""
+class TestRedisSessionMemoryServiceInit:
+  """Tests for RedisSessionMemoryService initialization."""
 
   def test_init_with_default_config(self):
     """Test initialization with default config."""
-    service = RedisWorkingMemorySessionService()
+    service = RedisSessionMemoryService()
     assert service._config.api_base_url == "http://localhost:8000"
 
   def test_init_with_custom_config(self):
     """Test initialization with custom config."""
-    config = RedisWorkingMemorySessionServiceConfig(
+    config = RedisSessionMemoryServiceConfig(
         api_base_url="http://custom:9000",
     )
-    service = RedisWorkingMemorySessionService(config=config)
+    service = RedisSessionMemoryService(config=config)
     assert service._config.api_base_url == "http://custom:9000"
 
 
-class TestRedisWorkingMemorySessionServiceMethods:
-  """Tests for RedisWorkingMemorySessionService methods."""
+class TestRedisSessionMemoryServiceMethods:
+  """Tests for RedisSessionMemoryService methods."""
 
   @pytest.fixture
   def fake_client(self):
@@ -152,8 +152,8 @@ class TestRedisWorkingMemorySessionServiceMethods:
   @pytest.fixture
   def service(self, fake_client):
     """Create a service instance for testing."""
-    service = RedisWorkingMemorySessionService(
-        RedisWorkingMemorySessionServiceConfig(default_namespace="test_ns")
+    service = RedisSessionMemoryService(
+        RedisSessionMemoryServiceConfig(default_namespace="test_ns")
     )
     with patch.object(service, "_get_client", return_value=fake_client):
       yield service
@@ -350,8 +350,8 @@ class TestRedisWorkingMemorySessionServiceMethods:
     """Test list_sessions can use the self-hosted backend."""
     fake_client = FakeAgentMemoryServerClient()
     fake_client.list_response = SimpleNamespace(sessions=["session-1"])
-    service = RedisWorkingMemorySessionService(
-        RedisWorkingMemorySessionServiceConfig(
+    service = RedisSessionMemoryService(
+        RedisSessionMemoryServiceConfig(
             backend=OPENSOURCE_AGENT_MEMORY_BACKEND,
             default_namespace="test_ns",
         )

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -45,24 +45,48 @@ class TestSessionImports:
   """Test session module imports."""
 
   def test_session_service_import(self):
-    """Test RedisWorkingMemorySessionService can be imported."""
-    from adk_redis import RedisWorkingMemorySessionService
+    """Test RedisSessionMemoryService can be imported."""
+    from adk_redis import RedisSessionMemoryService
 
-    assert RedisWorkingMemorySessionService is not None
+    assert RedisSessionMemoryService is not None
 
   def test_session_config_import(self):
-    """Test RedisWorkingMemorySessionServiceConfig can be imported."""
-    from adk_redis import RedisWorkingMemorySessionServiceConfig
+    """Test RedisSessionMemoryServiceConfig can be imported."""
+    from adk_redis import RedisSessionMemoryServiceConfig
 
-    assert RedisWorkingMemorySessionServiceConfig is not None
+    assert RedisSessionMemoryServiceConfig is not None
 
   def test_session_submodule_import(self):
     """Test sessions submodule imports."""
-    from adk_redis.sessions import RedisWorkingMemorySessionService
-    from adk_redis.sessions import RedisWorkingMemorySessionServiceConfig
+    from adk_redis.sessions import RedisSessionMemoryService
+    from adk_redis.sessions import RedisSessionMemoryServiceConfig
 
-    assert RedisWorkingMemorySessionService is not None
-    assert RedisWorkingMemorySessionServiceConfig is not None
+    assert RedisSessionMemoryService is not None
+    assert RedisSessionMemoryServiceConfig is not None
+
+  def test_deprecated_session_aliases(self):
+    """Deprecated aliases still import and subclass the new names."""
+    import warnings
+
+    from adk_redis import RedisSessionMemoryService
+    from adk_redis import RedisSessionMemoryServiceConfig
+    from adk_redis import RedisWorkingMemorySessionService
+    from adk_redis import RedisWorkingMemorySessionServiceConfig
+
+    assert issubclass(
+        RedisWorkingMemorySessionService, RedisSessionMemoryService
+    )
+    assert issubclass(
+        RedisWorkingMemorySessionServiceConfig, RedisSessionMemoryServiceConfig
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+      warnings.simplefilter("always")
+      RedisWorkingMemorySessionService()
+      RedisWorkingMemorySessionServiceConfig()
+
+    categories = [w.category for w in caught]
+    assert categories.count(DeprecationWarning) == 2
 
 
 class TestToolImports:

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -14,6 +14,10 @@
 
 """Tests for package imports."""
 
+import importlib
+import sys
+import warnings
+
 import pytest
 
 
@@ -66,8 +70,6 @@ class TestSessionImports:
 
   def test_deprecated_session_aliases(self):
     """Deprecated aliases still import and subclass the new names."""
-    import warnings
-
     from adk_redis import RedisSessionMemoryService
     from adk_redis import RedisSessionMemoryServiceConfig
     from adk_redis import RedisWorkingMemorySessionService
@@ -87,6 +89,19 @@ class TestSessionImports:
 
     categories = [w.category for w in caught]
     assert categories.count(DeprecationWarning) == 2
+
+  def test_deprecated_session_module_path(self):
+    """Legacy module path still imports and warns until 0.1.0."""
+    sys.modules.pop("adk_redis.sessions.working_memory", None)
+    with warnings.catch_warnings(record=True) as caught:
+      warnings.simplefilter("always")
+      working_memory = importlib.import_module(
+          "adk_redis.sessions.working_memory"
+      )
+
+    assert working_memory.RedisWorkingMemorySessionService is not None
+    assert working_memory.RedisSessionMemoryService is not None
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 
 
 class TestToolImports:


### PR DESCRIPTION
## Summary

Renames the session service to align with the managed Redis Agent Memory **"session memory"** terminology and ADK's `<Backend>SessionService` convention.

- `RedisWorkingMemorySessionService` → `RedisSessionMemoryService`
- `RedisWorkingMemorySessionServiceConfig` → `RedisSessionMemoryServiceConfig`
- module `adk_redis.sessions.working_memory` → `adk_redis.sessions.session_memory`

`RedisLongTermMemoryService` is unchanged ("long-term memory" stays long-term memory).

## Backward compatibility

The old names remain as **deprecated aliases** that subclass the new classes and emit a `DeprecationWarning`. They are scheduled for removal in `0.1.0`. Existing code keeps working with a warning.

## Scope

- Code: class/config rename, module rename, `__init__` re-exports and `__all__`.
- Docs, examples, and tests moved to the new names (kept "working memory" only where it accurately describes the self-hosted Agent Memory Server feature/API).
- Version bumped `0.0.7` → `0.0.8` with `CHANGELOG` Changed + Deprecated entries.

## Testing

`make check` passes: format, lint, type-check, and 116 unit tests (10 live-backend integration tests skipped). Added a test covering the deprecated aliases (import, subclassing, and `DeprecationWarning`).
