### PR TITLE
chore(memory): upgrade redis agent memory sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.0.9] - 2026-07-31
+
+### Added
+
+- Cache providers now expose stable entry IDs from `check()` and `store()` and
+  support targeted invalidation through `delete_by_id()` without clearing
+  unrelated entries.
+- Memory tools resolve the acting user from the ADK `tool_context` before
+  falling back to configured defaults, allowing a shared runner to remain
+  scoped to each invocation user.
+- `CreateMemoryTool.run_async()` accepts an application-supplied `id` for
+  idempotent managed-memory writes. IDs are derived with namespace and user
+  scope to prevent cross-tenant collisions and are not exposed to the LLM.
+
+### Changed
+
+- The managed memory integration now requires `redis-agent-memory>=0.2.0`.
+  SDK method compatibility was verified across session memory, long-term
+  memory, and memory tools.
+- Documentation now covers cache entry IDs, targeted invalidation,
+  invocation-user resolution, scoped client IDs, and the updated managed SDK
+  requirement.
+
+### Fixed
+
+- Update and delete memory tools validate namespace and user ownership before
+  mutating records. Delete preflight reads use bounded concurrency.
+- Self-hosted memory warnings no longer log raw application-supplied IDs.
+
 ## [0.0.8] - 2026-06-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Memory backends are selected with `backend`:
 | `redis-agent-memory` | You want Redis Agent Memory managed by Redis or the Redis Agent Memory data plane | `redis-agent-memory` |
 | `opensource-agent-memory` | You want the open source self-hosted Agent Memory Server | `agent-memory-client` |
 
+The `memory` extra installs `redis-agent-memory>=0.2.0` for the managed
+backend.
+
 ---
 
 ## Quick start

--- a/docs/specs/redis-agent-memory-default.md
+++ b/docs/specs/redis-agent-memory-default.md
@@ -122,7 +122,7 @@ Agent Memory Server options:
 The `memory` extra installs both backend clients:
 
 - `agent-memory-client>=0.14.0`
-- `redis-agent-memory>=0.0.4`
+- `redis-agent-memory>=0.2.0`
 
 ## Tests
 

--- a/docs/user_guide/how_to_guides/managed_memory_setup.md
+++ b/docs/user_guide/how_to_guides/managed_memory_setup.md
@@ -12,6 +12,7 @@ with an API base URL, an API key, and a store ID.
 
 - Python 3.10+
 - `adk-redis` with the memory extra: `pip install "adk-redis[memory]"`.
+  The extra installs `redis-agent-memory>=0.2.0`.
 - A managed Redis Agent Memory service on Redis Cloud (see
   [Get credentials](#get-credentials) below).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 # Redis Agent Memory integrations (long-term memory + working memory sessions)
 memory = [
     "agent-memory-client>=0.14.0",
-    "redis-agent-memory>=0.0.4",
+    "redis-agent-memory>=0.2.0",
 ]
 
 # RedisVL-based search tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "adk-redis"
-version = "0.0.8"
+version = "0.0.9"
 description = "Redis integrations for Google's Agent Development Kit (ADK)"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Prepare the `adk-redis` 0.0.9 release.
- Raise the `redis-agent-memory` requirement from `>=0.0.4` to `>=0.2.0`, the latest PyPI release.
- Update the README, managed setup guide, backend specification, and changelog.

## 0.0.9 release notes

This release consolidates the three previously merged feature PRs:

- Stable cache entry IDs and targeted invalidation through `delete_by_id()`.
- Per-invocation memory-tool user resolution through ADK `tool_context`, including ownership validation for mutations.
- Tenant-scoped client IDs for idempotent `CreateMemoryTool` writes.

It also upgrades the managed Redis Agent Memory SDK requirement to `redis-agent-memory>=0.2.0` and prevents self-hosted warnings from logging supplied application IDs.

## Compatibility verification

Verified `redis-agent-memory` 0.2.0 against every SDK surface used by `adk-redis`:

- `AgentMemory` client construction
- Session event creation, retrieval, listing, and deletion
- Long-term memory search, create, retrieve, update, and bulk delete
- Memory tools using the corresponding async SDK methods

No application code changes were required because the used method signatures remain compatible.

## Validation

- Package version reports `0.0.9`
- Source distribution and wheel build successfully
- `make format`
- Ruff
- mypy
- Full pytest suite: 143 passed, 10 live-service tests skipped because external Redis services and credentials were not configured
- `uv lock --check`
- `mkdocs build`