### PR TITLE
docs(examples): add managed quickstart and label backends per example

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -88,6 +88,9 @@ agent = Agent(
 | `delete_long_term_memories` | Remove memories by ID |
 | `memory_prompt` | Enrich a prompt with relevant memories |
 | `set_working_memory` | Write to the current session's working memory |
+| `get_working_memory` | Read the current session's working memory |
+| `compact_long_term_memories` | Deduplicate and compact stored memories |
+| `get_current_datetime` | Resolve the current time for relative date reasoning |
 
 ## Option 2: SDK-Based Tools
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -9,24 +9,29 @@ directory and explains what it demonstrates.
 
 ## Memory and Sessions
 
-| Example | What it shows |
-|---------|---------------|
-| [**Simple Redis memory**](https://github.com/redis-developer/adk-redis/tree/main/examples/simple_redis_memory) | Minimal agent with `RedisSessionMemoryService` and `RedisLongTermMemoryService`. |
-| [**Fitness coach (MCP)**](https://github.com/redis-developer/adk-redis/tree/main/examples/fitness_coach_mcp) | MCP-based memory with `McpToolset` and Agent Memory Server. |
-| [**Travel agent (hybrid)**](https://github.com/redis-developer/adk-redis/tree/main/examples/travel_agent_memory_hybrid) | Framework-managed sessions + memory with vector search over travel docs. |
-| [**Travel agent (tools)**](https://github.com/redis-developer/adk-redis/tree/main/examples/travel_agent_memory_tools) | Same travel agent using LLM-controlled memory tools instead of framework services. |
+Each memory example targets a specific backend. The examples that exercise
+auto-summarization, extraction strategies, recency-boosted search, or MCP
+require the self-hosted `opensource-agent-memory` backend.
+
+| Example | Backend | Runner | What it shows |
+|---------|---------|--------|---------------|
+| [**Managed memory quickstart**](https://github.com/redis-developer/adk-redis/tree/main/examples/managed_memory_quickstart) | `redis-agent-memory` | `python main.py` | Smallest memory agent, on the managed backend. No Docker or Agent Memory Server. |
+| [**Simple Redis memory**](https://github.com/redis-developer/adk-redis/tree/main/examples/simple_redis_memory) | `opensource-agent-memory` | `python main.py` | Minimal agent with `RedisSessionMemoryService` and `RedisLongTermMemoryService`, plus auto-summarization and extraction. |
+| [**Fitness coach (MCP)**](https://github.com/redis-developer/adk-redis/tree/main/examples/fitness_coach_mcp) | `opensource-agent-memory` only | `adk web .` | MCP-based memory with `McpToolset` and Agent Memory Server. The managed backend has no MCP endpoint. |
+| [**Travel agent (hybrid)**](https://github.com/redis-developer/adk-redis/tree/main/examples/travel_agent_memory_hybrid) | `opensource-agent-memory` | `python main.py` | Framework-managed sessions + memory with vector search over travel docs. |
+| [**Travel agent (tools)**](https://github.com/redis-developer/adk-redis/tree/main/examples/travel_agent_memory_tools) | `opensource-agent-memory`, switchable | `adk web .` | Same travel agent using LLM-controlled memory tools instead of framework services. Set `REDIS_MEMORY_BACKEND` to switch backends. |
 
 ## Search
 
-| Example | What it shows |
-|---------|---------------|
-| [**Redis search tools**](https://github.com/redis-developer/adk-redis/tree/main/examples/redis_search_tools) | Vector, text, and range search tools in one agent. |
-| [**SQL search**](https://github.com/redis-developer/adk-redis/tree/main/examples/redis_sql_search) | `RedisSQLSearchTool` answering catalog questions via parameterized SQL. |
-| [**RedisVL MCP search**](https://github.com/redis-developer/adk-redis/tree/main/examples/redisvl_mcp_search) | Same knowledge base served via `rvl mcp` over MCP. |
+| Example | Runner | What it shows |
+|---------|--------|---------------|
+| [**Redis search tools**](https://github.com/redis-developer/adk-redis/tree/main/examples/redis_search_tools) | `adk web .` | Vector, text, and range search tools in one agent. |
+| [**SQL search**](https://github.com/redis-developer/adk-redis/tree/main/examples/redis_sql_search) | `adk web .` | `RedisSQLSearchTool` answering catalog questions via parameterized SQL. |
+| [**RedisVL MCP search**](https://github.com/redis-developer/adk-redis/tree/main/examples/redisvl_mcp_search) | `adk web .` | Same knowledge base served via `rvl mcp` over MCP. |
 
 ## Semantic Caching
 
-| Example | What it shows |
-|---------|---------------|
-| [**Semantic cache (RedisVL)**](https://github.com/redis-developer/adk-redis/tree/main/examples/semantic_cache) | Self-hosted semantic cache with `RedisVLCacheProvider`. |
-| [**LangCache cache**](https://github.com/redis-developer/adk-redis/tree/main/examples/langcache_cache) | Managed semantic cache with `LangCacheProvider`. |
+| Example | Runner | What it shows |
+|---------|--------|---------------|
+| [**Semantic cache (RedisVL)**](https://github.com/redis-developer/adk-redis/tree/main/examples/semantic_cache) | `python main.py` | Self-hosted semantic cache with `RedisVLCacheProvider`. |
+| [**LangCache cache**](https://github.com/redis-developer/adk-redis/tree/main/examples/langcache_cache) | `python main.py` | Managed semantic cache with `LangCacheProvider`. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ docker run -d --name redis -p 6379:6379 redis:8
 
     ---
 
-    Nine runnable agents covering memory, search, and caching.
+    Ten runnable agents covering memory, search, and caching.
 
 -   :material-api:{ .lg .middle } **[API Reference](api/index.md)**
 


### PR DESCRIPTION
## Why

The docs site examples page was missing `managed_memory_quickstart` entirely. That is the one example that runs on the default (`redis-agent-memory`) backend, so the quickest path to a working agent was not discoverable from the published docs at all.

The page also gave no way to tell which backend each memory example targets. That matters because half of them only work self-hosted, and `fitness_coach_mcp` cannot run on managed at any setting since the managed backend has no MCP endpoint.

## Changes

`docs/examples/index.md`

- Add `managed_memory_quickstart` to the memory table.
- Add a **Backend** column to the memory table and a **Runner** column to all three tables, mirroring what `examples/README.md` already tracks. Several examples run under `adk web .` rather than `python main.py`, which the page did not say.
- Note that auto-summarization, extraction strategies, recency-boosted search, and MCP require the self-hosted backend.

`docs/index.md`

- Said "Nine runnable agents"; there are ten.

`docs/concepts/memory.md`

- Complete the MCP tool table. Agent Memory Server exposes `get_working_memory`, `compact_long_term_memories`, and `get_current_datetime` in addition to the seven already listed. Verified against `agent_memory_server/mcp.py` rather than from the changelog.

## Verification

`mkdocs build --strict` produces **64 warnings on this branch and 64 on unmodified `main`**, none referencing the edited files. They are all pre-existing griffe docstring warnings in `src/adk_redis/tools/memory/` about parameters documented but absent from the wrapped signatures. Worth a separate cleanup, since they keep `--strict` from ever passing.

## Scope note

I checked the rest of the published pages against 0.0.9 and they are already current: cache entry IDs and `delete_by_id`, client-supplied memory IDs, invocation-user resolution, and all six memory tools are documented. This PR is deliberately small as a result.

Two things I left alone on purpose:

- `docs/for-ais-only/FAILURE_MODES.md` names `create_memory_mcp_toolset`, but as a prohibition ("do not introduce"), which is correct guidance.
- `docs/specs/examples-memory-coverage-handover.md:164` states the helper exists, which is stale, but it is an unpublished historical handover doc rather than user-facing content.

## Related

Companion redis.io update is redis/docs#3746, which brings those pages from 0.0.5 to 0.0.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)