### PR TITLE
feat(cache): attach to a pre-provisioned index, and contain cache failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,19 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
 
+    # Integration tests skip themselves unless a Redis with the search
+    # module is reachable at REDIS_URL.
+    services:
+      redis:
+        image: redis:8.4
+        ports:
+          - 6399:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
 
@@ -37,6 +50,8 @@ jobs:
         run: make type-check
 
       - name: Tests with coverage
+        env:
+          REDIS_URL: redis://localhost:6399
         run: uv run pytest tests --cov=adk_redis --cov-report=xml
 
       - name: Upload coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   is unchanged.
 - `RedisVLCacheProviderConfig.overwrite` exposes index overwrite as a
   configuration option.
+- `ignore_errors` on `LLMResponseCacheConfig` and `ToolCacheConfig`
+  defaults to True, logging cache backend failures and carrying on. Set it
+  to False while developing to raise instead of reading a log line.
 
 ### Changed
 
@@ -53,6 +56,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   cache's own entries in place.
 - Integration tests now run in CI, which had no Redis service, so the
   suite silently skipped every test requiring one.
+- Loggers are no longer named with a doubled package prefix. Every module
+  built its logger as `"adk_redis." + __name__` while `__name__` already
+  began with `adk_redis`, so the real logger was
+  `adk_redis.adk_redis.cache.llm_cache` and configuring
+  `adk_redis.cache` had no effect. Filtering on the top-level `adk_redis`
+  logger is unchanged.
 
 ## [0.0.9] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,30 +11,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - `RedisVLCacheProviderConfig.create_index` lets `RedisVLCacheProvider`
   attach to a search index provisioned outside adk-redis. With
-  `create_index=False` no index command is issued while the provider is
-  constructed, so the cache works on a credential that is denied `FT.INFO`
-  and `FT.CREATE`. The flag requires `redisvl>=0.26.0`, and requesting it on
-  an older release raises an `ImportError` naming the required version
-  instead of failing inside RedisVL. The `redisvl` floor stays at 0.18.2,
-  so the default path is unaffected.
+  `create_index=False` construction issues no index command, so the cache
+  runs on a credential denied `FT.INFO` and `FT.CREATE`. Requires
+  `redisvl>=0.26.0`; the package floor stays at 0.18.2 and the default path
+  is unchanged.
 - `RedisVLCacheProviderConfig.overwrite` exposes index overwrite as a
   configuration option.
-- The semantic cache guide documents the pre-provisioned index path, the
-  minimum ACL for each provider call, and the fact that `check()` still
-  needs `FT.SEARCH`.
 
 ### Changed
 
-- `RedisVLCacheProvider` no longer forces `overwrite=True`. An existing
-  index is now reused rather than dropped and recreated on every provider
-  construction, which removes `FT.DROPINDEX` and `FT.CREATE` from a path
-  most callers use only to read and write entries. A schema mismatch is
-  reported instead of being silently rebuilt, leaving entries embedded by a
-  different model behind. Set `overwrite=True` on
-  `RedisVLCacheProviderConfig` to restore the previous behavior.
-- Errors from RedisVL during cache construction are re-raised with the
-  `RedisVLCacheProviderConfig` fields that control the index, rather than
-  surfacing a bare RedisVL message.
+- **Breaking:** `RedisVLCacheProvider` no longer forces `overwrite=True`.
+  The default is now `False`, matching RedisVL, so an existing index is
+  reused instead of dropped and recreated on every construction. If your
+  index schema no longer matches the provider config, construction now
+  raises a `ValueError` naming `overwrite` where it previously rebuilt the
+  index silently and left entries embedded by the old model unindexed. To
+  migrate, set `overwrite=True` for one deployment to rebuild the index, or
+  drop it out of band with `FT.DROPINDEX <name>`.
+- `LLMResponseCache` and `ToolCache` no longer let a cache backend failure
+  abort the agent turn. A failed lookup falls through to the model or the
+  tool, and a failed write returns the response unchanged, both logged.
+  Previously any provider exception propagated out of the ADK callback and
+  ended the invocation with no events emitted.
+- Errors raised while RedisVL sets up the index are re-raised naming the
+  `RedisVLCacheProviderConfig` field that resolves them. A credential
+  denied `FT.INFO` is now pointed at `create_index`, and a drifted schema
+  at `overwrite`.
 - `RedisVLCacheProvider.clear()` deletes entries by scanning the cache key
   prefix when `create_index=False`, because RedisVL refuses index-wide
   destructive calls for an index it does not manage. The external index is
@@ -45,6 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `RedisVLCacheProvider.close()` no longer raises `AttributeError` when the
   provider never opened a connection, which is reachable with
   `create_index=False` because construction sends nothing to Redis.
+- `RedisVLCacheProvider.clear()` no longer builds its key scan from an
+  unescaped cache name. A name containing a glob metacharacter, such as
+  `cache[ab]`, matched unrelated keys and deleted them while leaving the
+  cache's own entries in place.
+- Integration tests now run in CI, which had no Redis service, so the
+  suite silently skipped every test requiring one.
 
 ## [0.0.9] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `RedisVLCacheProviderConfig.create_index` lets `RedisVLCacheProvider`
+  attach to a search index provisioned outside adk-redis. With
+  `create_index=False` no index command is issued while the provider is
+  constructed, so the cache works on a credential that is denied `FT.INFO`
+  and `FT.CREATE`. The flag requires `redisvl>=0.26.0`, and requesting it on
+  an older release raises an `ImportError` naming the required version
+  instead of failing inside RedisVL. The `redisvl` floor stays at 0.18.2,
+  so the default path is unaffected.
+- `RedisVLCacheProviderConfig.overwrite` exposes index overwrite as a
+  configuration option.
+- The semantic cache guide documents the pre-provisioned index path, the
+  minimum ACL for each provider call, and the fact that `check()` still
+  needs `FT.SEARCH`.
+
+### Changed
+
+- `RedisVLCacheProvider` no longer forces `overwrite=True`. An existing
+  index is now reused rather than dropped and recreated on every provider
+  construction, which removes `FT.DROPINDEX` and `FT.CREATE` from a path
+  most callers use only to read and write entries. A schema mismatch is
+  reported instead of being silently rebuilt, leaving entries embedded by a
+  different model behind. Set `overwrite=True` on
+  `RedisVLCacheProviderConfig` to restore the previous behavior.
+- Errors from RedisVL during cache construction are re-raised with the
+  `RedisVLCacheProviderConfig` fields that control the index, rather than
+  surfacing a bare RedisVL message.
+- `RedisVLCacheProvider.clear()` deletes entries by scanning the cache key
+  prefix when `create_index=False`, because RedisVL refuses index-wide
+  destructive calls for an index it does not manage. The external index is
+  never dropped.
+
+### Fixed
+
+- `RedisVLCacheProvider.close()` no longer raises `AttributeError` when the
+  provider never opened a connection, which is reachable with
+  `create_index=False` because construction sends nothing to Redis.
+
 ## [0.0.9] - 2026-07-31
 
 ### Added

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -163,6 +163,7 @@ For a given provider instance, identifiers returned by `check()` and `store()` a
 | `redis_url` | RedisVL | `redis://localhost:6379` | Redis connection string |
 | `cache_id` | LangCache | Required | LangCache instance identifier |
 | `api_key` | LangCache | Required | LangCache API key |
+| `ignore_errors` | Cache config | `True` | Log cache backend failures and carry on with the model or tool call |
 | `use_exact_search` | LangCache | `True` | Enable exact (hash) matching in addition to semantic |
 | `use_semantic_search` | LangCache | `True` | Enable semantic (vector) matching |
 

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -155,9 +155,11 @@ For a given provider instance, identifiers returned by `check()` and `store()` a
 
 | Option | Provider | Default | Description |
 |--------|----------|---------|-------------|
-| `distance_threshold` | Both | `0.1` | Max vector distance for a cache hit (lower = stricter) |
-| `ttl` | Both | `None` | Time-to-live in seconds for cache entries |
-| `name` | RedisVL | `llmcache` | Redis index name for the cache |
+| `distance_threshold` | Both | `0.1` (RedisVL), `None` (LangCache) | Max vector distance for a cache hit (lower = stricter). LangCache applies its server-side default when unset |
+| `ttl` | Both | `3600` (RedisVL), `None` (LangCache) | Time-to-live in seconds for cache entries |
+| `name` | RedisVL | `adk_semantic_cache` | Redis index name for the cache |
+| `create_index` | RedisVL | `True` | Whether RedisVL creates and validates the index. `False` attaches to an index provisioned elsewhere, for a credential denied `@search`. See the [how-to guide](../user_guide/how_to_guides/semantic_cache.md#attaching-to-a-pre-provisioned-index) |
+| `overwrite` | RedisVL | `False` | Whether to drop and recreate an existing index |
 | `redis_url` | RedisVL | `redis://localhost:6379` | Redis connection string |
 | `cache_id` | LangCache | Required | LangCache instance identifier |
 | `api_key` | LangCache | Required | LangCache API key |

--- a/docs/for-ais-only/FAILURE_MODES.md
+++ b/docs/for-ais-only/FAILURE_MODES.md
@@ -109,7 +109,10 @@ and outside its own model-error handling, so a raised exception ends the
 invocation with no events emitted, discarding a response the caller
 already paid for. Do not narrow these to specific exception types to
 "surface real errors"; a cache is an optimization and must not be able to
-break an agent turn. `tests/cache/test_fail_open.py` pins this.
+break an agent turn. Developers who want the exception set
+`ignore_errors=False` on `LLMResponseCacheConfig` or `ToolCacheConfig`.
+Construction errors are never absorbed. `tests/cache/test_fail_open.py`
+pins both paths.
 
 ## `overwrite` defaults to False, so a drifted schema raises
 

--- a/docs/for-ais-only/FAILURE_MODES.md
+++ b/docs/for-ais-only/FAILURE_MODES.md
@@ -37,7 +37,7 @@ tests in `tests/tools/test_vector_search.py::TestRedisVectorQueryConfigEpsilonRe
 
 The `redisvl.extensions.llmcache` path still works but emits a
 `DeprecationWarning`. The cache provider imports from
-`redisvl.extensions.cache.llm` (`cache/_provider.py:131`). Do not revert
+`redisvl.extensions.cache.llm` (`cache/_provider.py`). Do not revert
 to the old path; the regression test in
 `tests/cache/test_provider.py` asserts no `DeprecationWarning` fires.
 
@@ -87,3 +87,36 @@ is real. Either add a test or delete the unreachable branch.
 `sphinx-build -W` is the published build mode. Suppressing a warning to
 "make CI green" hides broken cross-references that later become 404s on
 the published docs site.
+
+## A mismatched attached index misses silently, it does not raise
+
+With `create_index=False` the cache provider attaches to an index it did
+not create, and RedisVL validates nothing about it. A wrong or absent
+index `name` raises `RedisSearchError` on the first `check()`, but a wrong
+vector dimension, key prefix, storage type, or distance metric is silent:
+entries are written, every lookup misses, and the cache adds latency
+while saving nothing. Do not "fix" this by adding an `FT.INFO` probe to
+the provider. That command is exactly what the credential is denied, and
+probing would defeat the feature. Verify the index out of band instead.
+`tests/integration/test_sql_and_cache_end_to_end.py` pins both shapes.
+
+## The cache swallows backend failures on purpose
+
+`LLMResponseCache` and `ToolCache` catch every exception from
+`provider.check()` and `provider.store()` and fall through to the model or
+the tool. This is deliberate: ADK awaits callbacks with no `try`/`except`
+and outside its own model-error handling, so a raised exception ends the
+invocation with no events emitted, discarding a response the caller
+already paid for. Do not narrow these to specific exception types to
+"surface real errors"; a cache is an optimization and must not be able to
+break an agent turn. `tests/cache/test_fail_open.py` pins this.
+
+## `overwrite` defaults to False, so a drifted schema raises
+
+`RedisVLCacheProvider` once hardcoded `overwrite=True`, which dropped and
+recreated the index on every construction. It now reuses an existing
+index, matching RedisVL's own default, so a config that no longer matches
+the index in Redis raises at construction where it previously appeared to
+succeed. That is the intended report, not a regression: the old default
+hid the real problem, leaving entries embedded by a previous model in the
+keyspace, unindexed. Set `overwrite=True` to rebuild deliberately.

--- a/docs/for-ais-only/REPOSITORY_MAP.md
+++ b/docs/for-ais-only/REPOSITORY_MAP.md
@@ -36,7 +36,8 @@ src/adk_redis/
 
   cache/
     __init__.py           Re-exports the cache providers.
-    _provider.py          Provider protocol and base class.
+    _provider.py          Provider base class plus the RedisVL and
+                          LangCache implementations.
     llm_cache.py          Wraps an LLM call site with semantic caching.
     tool_cache.py         Wraps a tool call site with semantic caching.
     callbacks.py          ADK callback hooks for cache integration.
@@ -68,7 +69,9 @@ tests/
     test_search_tools_end_to_end.py    Real Redis 8.4: vector/text/range/
                                        native hybrid round-trips.
     test_sql_and_cache_end_to_end.py   Real Redis 8.4: SQL SELECT with
-                                       params, cache round-trip.
+                                       params, cache round-trip,
+                                       pre-provisioned index, and an
+                                       ACL-restricted credential.
     test_adk_agent_registration.py     Tools register with google.adk.Agent
                                        and surface via canonical_tools().
 ```

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -69,7 +69,8 @@ When generating code that uses adk-redis:
   `--read-only` to `rvl mcp` in stdio mode.
 - Set `stopwords=None` on text-search configs if `nltk` is not installed.
 - Pin `redisvl>=0.18.2` when documenting installs; the deprecated
-  `redisvl.extensions.llmcache` path is on the way out.
+  `redisvl.extensions.llmcache` path is on the way out. The cache
+  provider's `create_index=False` additionally needs `redisvl>=0.26.0`.
 
 When generating code that uses adk-redis, never:
 

--- a/docs/user_guide/how_to_guides/semantic_cache.md
+++ b/docs/user_guide/how_to_guides/semantic_cache.md
@@ -64,6 +64,74 @@ See the
 [semantic_cache example](https://github.com/redis-developer/adk-redis/tree/main/examples/semantic_cache)
 for a runnable version.
 
+### Attaching to a pre-provisioned index
+
+By default the provider creates the cache index, which requires `FT.CREATE`
+and an `FT.INFO` probe to detect an existing index. Some deployments cannot
+do that from the application: a platform team provisions the index out of
+band, and the credential the agent runs under is denied index management.
+Set `create_index=False` to attach to that index instead of creating it.
+
+```python
+provider = RedisVLCacheProvider(
+    config=RedisVLCacheProviderConfig(
+        redis_url="redis://cache-user:password@redis.internal:6379",
+        name="my_cache",  # must match the pre-provisioned index name
+        ttl=3600,
+        distance_threshold=0.1,
+        create_index=False,
+    ),
+    vectorizer=vectorizer,
+)
+```
+
+Requires `redisvl>=0.26.0`. On older releases the provider raises an
+`ImportError` naming the required version. Leaving `create_index=True`, the
+default, keeps working on any supported `redisvl`.
+
+With `create_index=False` the provider issues no index command while being
+constructed, and RedisVL validates nothing about the index it attaches to.
+The index must already exist under the same name and key prefix, over the
+same storage type, with a vector field matching the vectorizer's dimensions.
+A mismatch is not reported: queries return no results instead of failing, so
+the cache silently misses on every prompt. Verify the index yourself with
+`FT.INFO <name>` from a credential that is allowed to run it.
+
+`create_index=False` cannot be combined with `overwrite=True`, because
+overwrite means drop and recreate. The provider rejects that combination with
+a `ValueError` before contacting Redis.
+
+#### Minimum ACL for the runtime path
+
+Measured on Redis 8.4. `FT.SEARCH` carries both the `@read` and `@search`
+categories, while `FT.CREATE` and `FT.INFO` carry only `@search`. So a
+`+@read +@write` grant is enough for the whole cache runtime path, and it is
+exactly the grant that makes the default `create_index=True` path fail.
+
+| Provider call | Redis commands | Allowed by `+@read +@write` |
+|---------------|----------------|-----------------------------|
+| Construction, `create_index=True` | `FT.INFO`, `FT.CREATE` | No |
+| Construction, `create_index=False` | none | Yes |
+| `store()` | `HSET`, `EXPIRE` | Yes |
+| `check()` | `FT.SEARCH` | Yes |
+| `delete_by_id()` | `DEL` | Yes |
+| `clear()` | `SCAN`, `DEL` | Yes |
+
+An ACL that revokes search explicitly, such as `+@read +@write -@search`,
+also removes `FT.SEARCH`. That credential can still write entries, but
+`check()` raises `RedisSearchError` and the cache never serves a hit, so it
+adds latency without saving any model calls. `create_index=False` removes the
+index management commands from the requirements, not the query itself.
+
+#### Index-wide destructive calls
+
+RedisVL refuses `clear()` and `delete()` on its extensions when
+`create_index=False`, because it does not own the index lifecycle.
+`RedisVLCacheProvider.clear()` handles that case by scanning the cache key
+prefix and deleting the entry keys directly, so it needs no index command and
+leaves the externally provisioned index in place. `delete_by_id()` deletes a
+single key and is unaffected. adk-redis never drops the index.
+
 ---
 
 ## Option B: Managed with LangCache
@@ -125,9 +193,11 @@ for a runnable version.
 | Option | Provider | Default | Description |
 |--------|----------|---------|-------------|
 | `distance_threshold` | Both | `0.1` | Max vector distance for a cache hit (lower = stricter) |
-| `ttl` | Both | `None` | Time-to-live in seconds for cache entries |
-| `name` | RedisVL | `llmcache` | Redis index name |
+| `ttl` | Both | `3600` (RedisVL), `None` (LangCache) | Time-to-live in seconds for cache entries |
+| `name` | RedisVL | `adk_semantic_cache` | Redis index name |
 | `redis_url` | RedisVL | `redis://localhost:6379` | Redis connection string |
+| `create_index` | RedisVL | `True` | Whether RedisVL creates and validates the index. `False` attaches to a pre-provisioned index and issues no index command. Requires `redisvl>=0.26.0` |
+| `overwrite` | RedisVL | `False` | Whether to drop and recreate an existing index. Cannot be combined with `create_index=False` |
 | `cache_id` | LangCache | Required | LangCache instance identifier |
 | `api_key` | LangCache | Required | LangCache API key |
 | `first_message_only` | Cache config | `True` | Only cache the first message per session |

--- a/docs/user_guide/how_to_guides/semantic_cache.md
+++ b/docs/user_guide/how_to_guides/semantic_cache.md
@@ -139,6 +139,26 @@ An ACL that revokes search explicitly, `+@read +@write -@search`, loses
 `FT.SEARCH` as well: entries still store, but every lookup fails and the
 cache never serves a hit.
 
+#### Seeing failures while developing
+
+A cache backend failure is logged and the turn proceeds, so a broken cache
+costs latency rather than breaking the agent. That also means a
+misconfiguration can read as "caching just isn't working". While developing,
+set `ignore_errors=False` to raise instead:
+
+```python
+llm_cache = LLMResponseCache(
+    provider=provider,
+    config=LLMResponseCacheConfig(ignore_errors=False),
+)
+```
+
+Misconfiguration is still loud by default: a bad `redis_url`, a schema
+mismatch, a denied `FT.INFO`, or a too-old redisvl all raise when the
+provider is constructed. Only runtime lookup and store failures are
+absorbed. To turn up the logs instead, raise the verbosity of the
+`adk_redis.cache` logger.
+
 #### Clearing entries
 
 RedisVL refuses `clear()` and `delete()` on an index it does not manage, so
@@ -216,3 +236,4 @@ for a runnable version.
 | `cache_id` | LangCache | Required | LangCache instance identifier |
 | `api_key` | LangCache | Required | LangCache API key |
 | `first_message_only` | Cache config | `True` | Only cache the first message per session |
+| `ignore_errors` | Cache config | `True` | Log cache backend failures and carry on. Set `False` while developing to raise instead |

--- a/docs/user_guide/how_to_guides/semantic_cache.md
+++ b/docs/user_guide/how_to_guides/semantic_cache.md
@@ -66,17 +66,17 @@ for a runnable version.
 
 ### Attaching to a pre-provisioned index
 
-By default the provider creates the cache index, which requires `FT.CREATE`
-and an `FT.INFO` probe to detect an existing index. Some deployments cannot
-do that from the application: a platform team provisions the index out of
-band, and the credential the agent runs under is denied index management.
-Set `create_index=False` to attach to that index instead of creating it.
+By default the provider creates the cache index, which needs `FT.CREATE` plus
+an `FT.INFO` probe to detect an existing one. Where a platform team
+provisions the index out of band and the agent credential is denied index
+management, set `create_index=False` to attach to it instead. Requires
+`redisvl>=0.26.0`.
 
 ```python
 provider = RedisVLCacheProvider(
     config=RedisVLCacheProviderConfig(
         redis_url="redis://cache-user:password@redis.internal:6379",
-        name="my_cache",  # must match the pre-provisioned index name
+        name="my_cache",  # must match the pre-provisioned index
         ttl=3600,
         distance_threshold=0.1,
         create_index=False,
@@ -85,52 +85,67 @@ provider = RedisVLCacheProvider(
 )
 ```
 
-Requires `redisvl>=0.26.0`. On older releases the provider raises an
-`ImportError` naming the required version. Leaving `create_index=True`, the
-default, keeps working on any supported `redisvl`.
+#### Provisioning the index
 
-With `create_index=False` the provider issues no index command while being
-constructed, and RedisVL validates nothing about the index it attaches to.
-The index must already exist under the same name and key prefix, over the
-same storage type, with a vector field matching the vectorizer's dimensions.
-A mismatch is not reported: queries return no results instead of failing, so
-the cache silently misses on every prompt. Verify the index yourself with
-`FT.INFO <name>` from a credential that is allowed to run it.
+RedisVL derives the schema from the cache name and the vectorizer. For
+`name="my_cache"` over a 768 dimension vectorizer, provision the equivalent
+of:
 
-`create_index=False` cannot be combined with `overwrite=True`, because
-overwrite means drop and recreate. The provider rejects that combination with
-a `ValueError` before contacting Redis.
+```
+FT.CREATE my_cache ON HASH PREFIX 1 my_cache SCHEMA
+  prompt TEXT response TEXT inserted_at NUMERIC updated_at NUMERIC
+  prompt_vector VECTOR FLAT 6 TYPE FLOAT32 DIM 768 DISTANCE_METRIC COSINE
+```
 
-#### Minimum ACL for the runtime path
+The index prefix is the bare name while entry keys are `my_cache:<entry_id>`.
+So a credential's key pattern must cover `my_cache*`, not `my_cache:*`, and a
+second cache whose name extends this one, such as `my_cache_v2`, is covered by
+this index and returns the other cache's entries as hits. Give each cache a
+name that is not a prefix of another.
 
-Measured on Redis 8.4. `FT.SEARCH` carries both the `@read` and `@search`
-categories, while `FT.CREATE` and `FT.INFO` carry only `@search`. So a
-`+@read +@write` grant is enough for the whole cache runtime path, and it is
-exactly the grant that makes the default `create_index=True` path fail.
+!!! warning "The attached index is not validated"
 
-| Provider call | Redis commands | Allowed by `+@read +@write` |
-|---------------|----------------|-----------------------------|
-| Construction, `create_index=True` | `FT.INFO`, `FT.CREATE` | No |
-| Construction, `create_index=False` | none | Yes |
-| `store()` | `HSET`, `EXPIRE` | Yes |
-| `check()` | `FT.SEARCH` | Yes |
-| `delete_by_id()` | `DEL` | Yes |
-| `clear()` | `SCAN`, `DEL` | Yes |
+    RedisVL checks nothing about an index it did not create (verified on
+    redisvl 0.26.0). Which mismatches are loud depends on the field:
 
-An ACL that revokes search explicitly, such as `+@read +@write -@search`,
-also removes `FT.SEARCH`. That credential can still write entries, but
-`check()` raises `RedisSearchError` and the cache never serves a hit, so it
-adds latency without saving any model calls. `create_index=False` removes the
-index management commands from the requirements, not the query itself.
+    - Wrong or absent `name`: `check()` raises `RedisSearchError` on the
+      first lookup.
+    - Wrong vector dimensions, key prefix, storage type, or distance
+      metric: silent. Entries are written and TTLs set, every lookup
+      misses, and the cache stops saving model calls without erroring.
 
-#### Index-wide destructive calls
+    Confirm the index with `FT.INFO <name>` from a credential allowed to run
+    it before deploying.
 
-RedisVL refuses `clear()` and `delete()` on its extensions when
-`create_index=False`, because it does not own the index lifecycle.
-`RedisVLCacheProvider.clear()` handles that case by scanning the cache key
-prefix and deleting the entry keys directly, so it needs no index command and
-leaves the externally provisioned index in place. `delete_by_id()` deletes a
-single key and is unaffected. adk-redis never drops the index.
+#### Minimum ACL
+
+Measured on Redis 8.4, where `FT.SEARCH` carries both `@read` and `@search`
+while `FT.CREATE` and `FT.INFO` carry only `@search`. So
+`+@read +@write ~my_cache*` covers the entire runtime path and only index
+creation needs `@search`: `store()` issues `HSET` and `EXPIRE`, `check()`
+issues `FT.SEARCH` plus one `EXPIRE` per hit to refresh its TTL,
+`delete_by_id()` issues `UNLINK`, and `clear()` scans the key prefix and
+deletes. Three caveats:
+
+- Because `check()` refreshes TTLs, the read path needs `@write` too. A
+  read-only credential fails on lookup, not just on write.
+- On Redis Open Source 7.x with the RediSearch module, and on Redis Software
+  or Redis Cloud databases earlier than 8.2, module commands belong to no
+  category, so the grant must name the command: `+@read +@write +FT.SEARCH`.
+- A `redis_url` naming a non-zero database also needs `+SELECT`, which is in
+  `@connection`. Keep the cache on database 0 or grant it explicitly.
+
+An ACL that revokes search explicitly, `+@read +@write -@search`, loses
+`FT.SEARCH` as well: entries still store, but every lookup fails and the
+cache never serves a hit.
+
+#### Clearing entries
+
+RedisVL refuses `clear()` and `delete()` on an index it does not manage, so
+`clear()` deletes entries by scanning the `<name>:` key prefix instead. It
+issues no index command and never drops the index; `delete_by_id()` is
+unaffected. Neither is a barrier, because `SCAN` takes no snapshot, so an
+entry written concurrently may survive a `clear()`.
 
 ---
 
@@ -192,7 +207,7 @@ for a runnable version.
 
 | Option | Provider | Default | Description |
 |--------|----------|---------|-------------|
-| `distance_threshold` | Both | `0.1` | Max vector distance for a cache hit (lower = stricter) |
+| `distance_threshold` | Both | `0.1` (RedisVL), `None` (LangCache) | Max vector distance for a cache hit (lower = stricter). LangCache applies its server-side default when unset |
 | `ttl` | Both | `3600` (RedisVL), `None` (LangCache) | Time-to-live in seconds for cache entries |
 | `name` | RedisVL | `adk_semantic_cache` | Redis index name |
 | `redis_url` | RedisVL | `redis://localhost:6379` | Redis connection string |

--- a/src/adk_redis/cache/_provider.py
+++ b/src/adk_redis/cache/_provider.py
@@ -29,7 +29,7 @@ from pydantic import BaseModel
 from pydantic import Field
 from pydantic import SecretStr
 
-logger = logging.getLogger("adk_redis." + __name__)
+logger = logging.getLogger(__name__)
 
 # redisvl release that introduced the create_index flag on its extensions.
 _CREATE_INDEX_MIN_REDISVL = "0.26.0"

--- a/src/adk_redis/cache/_provider.py
+++ b/src/adk_redis/cache/_provider.py
@@ -20,8 +20,8 @@ from abc import ABC
 from abc import abstractmethod
 import asyncio
 from dataclasses import dataclass
-import importlib
 import importlib.metadata
+import inspect
 import logging
 from typing import Any, Optional
 
@@ -34,40 +34,42 @@ logger = logging.getLogger("adk_redis." + __name__)
 # redisvl release that introduced the create_index flag on its extensions.
 _CREATE_INDEX_MIN_REDISVL = "0.26.0"
 
-# Number of keys deleted per round trip when clearing an externally
-# managed cache index, matching the batch size RedisVL uses internally.
+# Keys per SCAN hint and per delete when clearing an externally managed
+# cache index, matching the batch size RedisVL uses internally.
 _CLEAR_BATCH_SIZE = 100
 
-
-def _redisvl_supports_create_index() -> bool:
-  """Report whether the installed redisvl accepts the create_index flag.
-
-  redisvl 0.26.0 added create_index alongside the
-  CREATE_INDEX_OVERWRITE_CONFLICT constant, so the presence of that
-  constant identifies a redisvl that can attach to an index it did not
-  create. The module is resolved dynamically because redisvl is an
-  optional dependency of adk-redis.
-
-  Returns:
-    True when the installed redisvl supports create_index.
-  """
-  try:
-    constants = importlib.import_module("redisvl.extensions.constants")
-  except ImportError:
-    return False
-  return hasattr(constants, "CREATE_INDEX_OVERWRITE_CONFLICT")
+# Characters Redis reads as glob metacharacters in a SCAN MATCH pattern.
+_GLOB_METACHARACTERS = frozenset("\\*?[]")
 
 
-def _installed_redisvl_version() -> str:
-  """Return the installed redisvl version for use in error messages.
+def _accepts_create_index(cache_cls: Any) -> bool:
+  """Report whether a RedisVL cache class accepts the create_index flag.
+
+  Args:
+    cache_cls: The RedisVL cache class the provider is about to construct.
 
   Returns:
-    The version string, or "not installed" when redisvl is absent.
+    True when the class accepts create_index, added in redisvl 0.26.0.
   """
-  try:
-    return importlib.metadata.version("redisvl")
-  except importlib.metadata.PackageNotFoundError:
-    return "not installed"
+  return "create_index" in inspect.signature(cache_cls).parameters
+
+
+def _escape_glob(literal: str) -> str:
+  """Escape Redis glob metacharacters so a pattern matches literally.
+
+  A cache named "cache[ab]" would otherwise build the SCAN pattern
+  "cache[ab]:*", which skips that cache's own keys and matches unrelated
+  "cachea:" and "cacheb:" keys instead.
+
+  Args:
+    literal: The string to match literally.
+
+  Returns:
+    The string with every glob metacharacter backslash escaped.
+  """
+  return "".join(
+      "\\" + char if char in _GLOB_METACHARACTERS else char for char in literal
+  )
 
 
 @dataclass
@@ -183,21 +185,17 @@ class RedisVLCacheProviderConfig(BaseModel):
   create_index: bool = Field(
       default=True,
       description=(
-          "Whether RedisVL creates and validates the cache index. Set to"
-          " False to attach to an index provisioned outside adk-redis, for"
-          " example by a platform team on a credential without @search"
-          " permissions. The index must already exist under the same name"
-          " and prefix; its schema is not verified. Requires"
-          " redisvl>=0.26.0."
+          "Whether RedisVL creates and validates the cache index. False"
+          " attaches to an index provisioned outside adk-redis without"
+          " verifying its schema. Requires"
+          f" redisvl>={_CREATE_INDEX_MIN_REDISVL}."
       ),
   )
   overwrite: bool = Field(
       default=False,
       description=(
           "Whether to drop and recreate the index when it already exists."
-          " Leave False so an existing index is reused and a schema"
-          " mismatch is reported instead of silently rebuilt. Cannot be"
-          " combined with create_index=False."
+          " Cannot be combined with create_index=False."
       ),
   )
 
@@ -256,13 +254,15 @@ class RedisVLCacheProvider(BaseCacheProvider):
       vectorizer: RedisVL vectorizer used to embed prompts.
 
     Raises:
-      ImportError: If redisvl is not installed, or if create_index is False
-        on a redisvl older than 0.26.0.
-      ValueError: If the configuration cannot be applied to the index, for
-        instance create_index=False combined with overwrite=True, or an
-        existing index whose schema differs from this configuration.
+      ImportError: If redisvl is not installed.
+      ValueError: If create_index is False on a redisvl older than 0.26.0,
+        if create_index=False is combined with overwrite=True, or if an
+        existing index's schema differs from this configuration.
+      RedisSearchError: If RedisVL cannot manage the index, for instance
+        when the credential is denied FT.INFO or FT.CREATE.
     """
     try:
+      from redisvl.exceptions import RedisSearchError
       from redisvl.extensions.cache.llm import SemanticCache
     except ImportError as e:
       raise ImportError(
@@ -273,47 +273,69 @@ class RedisVLCacheProvider(BaseCacheProvider):
     self._config = config
     self._vectorizer = vectorizer
 
-    cache_kwargs: dict[str, Any] = {
-        "name": config.name,
-        "redis_url": config.redis_url,
-        "ttl": config.ttl,
-        "distance_threshold": config.distance_threshold,
-        "vectorizer": vectorizer,
-        "overwrite": config.overwrite,
-    }
     # create_index is only forwarded when it is turned off, so the provider
     # keeps working against releases predating the flag.
+    extra: dict[str, Any] = {}
     if not config.create_index:
+      if not _accepts_create_index(SemanticCache):
+        raise ValueError(
+            "RedisVLCacheProviderConfig.create_index=False requires"
+            f" redisvl>={_CREATE_INDEX_MIN_REDISVL}, found"
+            f" {importlib.metadata.version('redisvl')}. Upgrade with: pip"
+            f" install 'redisvl>={_CREATE_INDEX_MIN_REDISVL}', or leave"
+            " create_index=True to have RedisVL create the index."
+        )
       if config.overwrite:
         raise ValueError(
             "RedisVLCacheProviderConfig sets create_index=False together"
-            " with overwrite=True, which contradict each other: overwrite"
-            " drops and recreates the index, but create_index=False leaves"
-            " the index under external management. Set overwrite=False to"
-            " attach to a pre-provisioned index, or create_index=True to"
-            " let RedisVL own the index."
+            " with overwrite=True. Set overwrite=False to attach to a"
+            " pre-provisioned index, or create_index=True to let RedisVL"
+            " own the index."
         )
-      if not _redisvl_supports_create_index():
-        raise ImportError(
-            "RedisVLCacheProviderConfig.create_index=False requires"
-            f" redisvl>={_CREATE_INDEX_MIN_REDISVL}, found"
-            f" {_installed_redisvl_version()}. Upgrade with: pip install"
-            f" 'redisvl>={_CREATE_INDEX_MIN_REDISVL}', or leave"
-            " create_index=True to have RedisVL create the index."
-        )
-      cache_kwargs["create_index"] = False
+      extra["create_index"] = False
 
     try:
-      self._cache = SemanticCache(**cache_kwargs)
-    except ValueError as e:
-      raise ValueError(
-          "RedisVL rejected the semantic cache configuration for index"
-          f" {config.name!r}: {e} Adjust name, create_index, or overwrite on"
-          " RedisVLCacheProviderConfig so they match the index in Redis."
+      self._cache = SemanticCache(
+          name=config.name,
+          redis_url=config.redis_url,
+          ttl=config.ttl,
+          distance_threshold=config.distance_threshold,
+          vectorizer=vectorizer,
+          overwrite=config.overwrite,
+          **extra,
+      )
+    except RedisSearchError as e:
+      raise RedisSearchError(
+          f"RedisVL could not manage the index {config.name!r}: {e}. If this"
+          " credential is denied FT.INFO and FT.CREATE, set create_index="
+          "False on RedisVLCacheProviderConfig to attach to an index"
+          " provisioned elsewhere."
       ) from e
+    except ValueError as e:
+      # Only a schema mismatch is worth rewriting. Anything else, such as a
+      # malformed redis_url, already names the field the caller must fix.
+      if "schema does not match" not in str(e):
+        raise
+      raise ValueError(
+          f"RedisVL rejected the existing index {config.name!r}: {e} Set"
+          " overwrite=True on RedisVLCacheProviderConfig to rebuild it, or"
+          " create_index=False to attach to it without validation."
+      ) from e
+
+  def _key_prefix(self) -> str:
+    """Return the Redis key prefix RedisVL writes cache entries under.
+
+    Returns:
+      The prefix, which RedisVL derives from the cache name.
+    """
+    prefix: str = self._cache._get_prefix()
+    return prefix
 
   async def check(self, prompt: str, **kwargs: Any) -> Optional[CacheEntry]:
     """Check for a semantically similar prompt in the cache.
+
+    RedisVL refreshes each hit's TTL, so this issues EXPIRE alongside
+    FT.SEARCH and needs write as well as read permissions.
 
     Args:
       prompt: The prompt to look up.
@@ -357,8 +379,7 @@ class RedisVLCacheProvider(BaseCacheProvider):
     key: str = await asyncio.to_thread(
         self._cache.store, prompt=prompt, response=response
     )
-    key_prefix = f"{self._config.name}:"
-    entry_id = key.removeprefix(key_prefix)
+    entry_id = key.removeprefix(self._key_prefix())
     logger.debug("Stored response for prompt: %s", prompt[:50])
     return entry_id
 
@@ -378,32 +399,30 @@ class RedisVLCacheProvider(BaseCacheProvider):
   def _clear_external_index_entries(self) -> None:
     """Delete every cache entry key without touching the index.
 
-    RedisVL refuses index-wide destructive calls when create_index is False,
-    because it does not own the index lifecycle. Entries are still plain
-    Redis keys under the cache prefix, so they are scanned and deleted
-    directly. That needs no @search permissions and leaves the externally
-    provisioned index in place.
+    This mirrors RedisVL's own BaseCache.clear, which is a prefix scan and
+    delete issuing no index command. RedisVL refuses that call on a cache
+    whose index it does not manage, so the scan is repeated here, leaving
+    the externally provisioned index in place.
+
+    SCAN offers no snapshot, so an entry written by another process while
+    this runs may survive.
     """
     client = self._cache._get_redis_client()
-    prefix = f"{self._config.name}:"
-    # Keys arrive as str or bytes depending on the client's decode setting,
-    # and both are accepted by DEL.
+    pattern = f"{_escape_glob(self._key_prefix())}*"
+    # Keys arrive as str or bytes depending on the client's decode setting.
     batch: list[Any] = []
-    for key in client.scan_iter(match=f"{prefix}*", count=_CLEAR_BATCH_SIZE):
+    for key in client.scan_iter(match=pattern, count=_CLEAR_BATCH_SIZE):
       batch.append(key)
       if len(batch) >= _CLEAR_BATCH_SIZE:
-        client.delete(*batch)
+        self._cache.drop(keys=batch)
         batch = []
     if batch:
-      client.delete(*batch)
+      self._cache.drop(keys=batch)
 
   async def clear(self, **kwargs: Any) -> None:
-    """Clear all entries from the cache.
+    """Clear all entries from the cache, leaving the index in place.
 
-    When create_index is False the entries are removed by scanning the cache
-    key prefix, because RedisVL raises on clear() for an index it does not
-    manage. The index itself is never dropped in that case.
-
+    See _clear_external_index_entries() for the create_index=False path.
     For removing a single entry, use delete_by_id() instead.
     """
     if self._config.create_index:
@@ -417,8 +436,10 @@ class RedisVLCacheProvider(BaseCacheProvider):
 
     RedisVL connects lazily, so a provider that issued no command yet holds
     no client. That is reachable when create_index is False, because
-    construction sends nothing to Redis. disconnect() tolerates the missing
-    client and leaves a caller-supplied client open.
+    construction sends nothing to Redis, and disconnect() tolerates it.
+
+    ADK does not call this: a Runner knows nothing about objects reachable
+    only through a callback, so the application owns the provider lifetime.
     """
     await asyncio.to_thread(self._cache.disconnect)
     logger.debug("RedisVL cache provider closed")

--- a/src/adk_redis/cache/_provider.py
+++ b/src/adk_redis/cache/_provider.py
@@ -20,6 +20,8 @@ from abc import ABC
 from abc import abstractmethod
 import asyncio
 from dataclasses import dataclass
+import importlib
+import importlib.metadata
 import logging
 from typing import Any, Optional
 
@@ -28,6 +30,44 @@ from pydantic import Field
 from pydantic import SecretStr
 
 logger = logging.getLogger("adk_redis." + __name__)
+
+# redisvl release that introduced the create_index flag on its extensions.
+_CREATE_INDEX_MIN_REDISVL = "0.26.0"
+
+# Number of keys deleted per round trip when clearing an externally
+# managed cache index, matching the batch size RedisVL uses internally.
+_CLEAR_BATCH_SIZE = 100
+
+
+def _redisvl_supports_create_index() -> bool:
+  """Report whether the installed redisvl accepts the create_index flag.
+
+  redisvl 0.26.0 added create_index alongside the
+  CREATE_INDEX_OVERWRITE_CONFLICT constant, so the presence of that
+  constant identifies a redisvl that can attach to an index it did not
+  create. The module is resolved dynamically because redisvl is an
+  optional dependency of adk-redis.
+
+  Returns:
+    True when the installed redisvl supports create_index.
+  """
+  try:
+    constants = importlib.import_module("redisvl.extensions.constants")
+  except ImportError:
+    return False
+  return hasattr(constants, "CREATE_INDEX_OVERWRITE_CONFLICT")
+
+
+def _installed_redisvl_version() -> str:
+  """Return the installed redisvl version for use in error messages.
+
+  Returns:
+    The version string, or "not installed" when redisvl is absent.
+  """
+  try:
+    return importlib.metadata.version("redisvl")
+  except importlib.metadata.PackageNotFoundError:
+    return "not installed"
 
 
 @dataclass
@@ -140,6 +180,26 @@ class RedisVLCacheProviderConfig(BaseModel):
   name: str = Field(default="adk_semantic_cache")
   ttl: int = Field(default=3600, ge=0)
   distance_threshold: float = Field(default=0.1, ge=0.0, le=2.0)
+  create_index: bool = Field(
+      default=True,
+      description=(
+          "Whether RedisVL creates and validates the cache index. Set to"
+          " False to attach to an index provisioned outside adk-redis, for"
+          " example by a platform team on a credential without @search"
+          " permissions. The index must already exist under the same name"
+          " and prefix; its schema is not verified. Requires"
+          " redisvl>=0.26.0."
+      ),
+  )
+  overwrite: bool = Field(
+      default=False,
+      description=(
+          "Whether to drop and recreate the index when it already exists."
+          " Leave False so an existing index is reused and a schema"
+          " mismatch is reported instead of silently rebuilt. Cannot be"
+          " combined with create_index=False."
+      ),
+  )
 
 
 class LangCacheProviderConfig(BaseModel):
@@ -189,7 +249,19 @@ class RedisVLCacheProvider(BaseCacheProvider):
   """Cache provider using RedisVL's SemanticCache."""
 
   def __init__(self, config: RedisVLCacheProviderConfig, vectorizer: Any):
-    """Initialize the RedisVL cache provider."""
+    """Initialize the RedisVL cache provider.
+
+    Args:
+      config: Configuration for the cache and its index.
+      vectorizer: RedisVL vectorizer used to embed prompts.
+
+    Raises:
+      ImportError: If redisvl is not installed, or if create_index is False
+        on a redisvl older than 0.26.0.
+      ValueError: If the configuration cannot be applied to the index, for
+        instance create_index=False combined with overwrite=True, or an
+        existing index whose schema differs from this configuration.
+    """
     try:
       from redisvl.extensions.cache.llm import SemanticCache
     except ImportError as e:
@@ -200,14 +272,45 @@ class RedisVLCacheProvider(BaseCacheProvider):
 
     self._config = config
     self._vectorizer = vectorizer
-    self._cache = SemanticCache(
-        name=config.name,
-        redis_url=config.redis_url,
-        ttl=config.ttl,
-        distance_threshold=config.distance_threshold,
-        vectorizer=vectorizer,
-        overwrite=True,  # Overwrite existing index if schema doesn't match
-    )
+
+    cache_kwargs: dict[str, Any] = {
+        "name": config.name,
+        "redis_url": config.redis_url,
+        "ttl": config.ttl,
+        "distance_threshold": config.distance_threshold,
+        "vectorizer": vectorizer,
+        "overwrite": config.overwrite,
+    }
+    # create_index is only forwarded when it is turned off, so the provider
+    # keeps working against releases predating the flag.
+    if not config.create_index:
+      if config.overwrite:
+        raise ValueError(
+            "RedisVLCacheProviderConfig sets create_index=False together"
+            " with overwrite=True, which contradict each other: overwrite"
+            " drops and recreates the index, but create_index=False leaves"
+            " the index under external management. Set overwrite=False to"
+            " attach to a pre-provisioned index, or create_index=True to"
+            " let RedisVL own the index."
+        )
+      if not _redisvl_supports_create_index():
+        raise ImportError(
+            "RedisVLCacheProviderConfig.create_index=False requires"
+            f" redisvl>={_CREATE_INDEX_MIN_REDISVL}, found"
+            f" {_installed_redisvl_version()}. Upgrade with: pip install"
+            f" 'redisvl>={_CREATE_INDEX_MIN_REDISVL}', or leave"
+            " create_index=True to have RedisVL create the index."
+        )
+      cache_kwargs["create_index"] = False
+
+    try:
+      self._cache = SemanticCache(**cache_kwargs)
+    except ValueError as e:
+      raise ValueError(
+          "RedisVL rejected the semantic cache configuration for index"
+          f" {config.name!r}: {e} Adjust name, create_index, or overwrite on"
+          " RedisVLCacheProviderConfig so they match the index in Redis."
+      ) from e
 
   async def check(self, prompt: str, **kwargs: Any) -> Optional[CacheEntry]:
     """Check for a semantically similar prompt in the cache.
@@ -272,18 +375,52 @@ class RedisVLCacheProvider(BaseCacheProvider):
     await asyncio.to_thread(self._cache.drop, ids=[entry_id])
     logger.debug("Dropped cache entry: %s", entry_id)
 
+  def _clear_external_index_entries(self) -> None:
+    """Delete every cache entry key without touching the index.
+
+    RedisVL refuses index-wide destructive calls when create_index is False,
+    because it does not own the index lifecycle. Entries are still plain
+    Redis keys under the cache prefix, so they are scanned and deleted
+    directly. That needs no @search permissions and leaves the externally
+    provisioned index in place.
+    """
+    client = self._cache._get_redis_client()
+    prefix = f"{self._config.name}:"
+    # Keys arrive as str or bytes depending on the client's decode setting,
+    # and both are accepted by DEL.
+    batch: list[Any] = []
+    for key in client.scan_iter(match=f"{prefix}*", count=_CLEAR_BATCH_SIZE):
+      batch.append(key)
+      if len(batch) >= _CLEAR_BATCH_SIZE:
+        client.delete(*batch)
+        batch = []
+    if batch:
+      client.delete(*batch)
+
   async def clear(self, **kwargs: Any) -> None:
     """Clear all entries from the cache.
 
+    When create_index is False the entries are removed by scanning the cache
+    key prefix, because RedisVL raises on clear() for an index it does not
+    manage. The index itself is never dropped in that case.
+
     For removing a single entry, use delete_by_id() instead.
     """
-    await asyncio.to_thread(self._cache.clear)
+    if self._config.create_index:
+      await asyncio.to_thread(self._cache.clear)
+    else:
+      await asyncio.to_thread(self._clear_external_index_entries)
     logger.info("Cache cleared")
 
   async def close(self) -> None:
-    """Close the cache provider and release resources."""
-    if hasattr(self._cache, "_index") and hasattr(self._cache._index, "client"):
-      await asyncio.to_thread(self._cache._index.client.close)
+    """Close the cache provider and release resources.
+
+    RedisVL connects lazily, so a provider that issued no command yet holds
+    no client. That is reachable when create_index is False, because
+    construction sends nothing to Redis. disconnect() tolerates the missing
+    client and leaves a caller-supplied client open.
+    """
+    await asyncio.to_thread(self._cache.disconnect)
     logger.debug("RedisVL cache provider closed")
 
 

--- a/src/adk_redis/cache/llm_cache.py
+++ b/src/adk_redis/cache/llm_cache.py
@@ -28,7 +28,7 @@ from pydantic import Field
 
 from ._provider import BaseCacheProvider
 
-logger = logging.getLogger("adk_redis." + __name__)
+logger = logging.getLogger(__name__)
 
 
 class LLMResponseCacheConfig(BaseModel):
@@ -39,12 +39,17 @@ class LLMResponseCacheConfig(BaseModel):
       include_app_name: Include app name in cache key.
       include_user_id: Include user ID in cache key.
       include_session_id: Include session ID in cache key.
+      ignore_errors: Log cache backend failures and carry on with the model
+          call instead of raising. Leave True in production, where a cache
+          must not be able to break an agent turn. Set False while
+          developing to see the failure instead of a log line.
   """
 
   first_message_only: bool = Field(default=True)
   include_app_name: bool = Field(default=True)
   include_user_id: bool = Field(default=True)
   include_session_id: bool = Field(default=False)
+  ignore_errors: bool = Field(default=True)
 
 
 class LLMResponseCache:
@@ -153,7 +158,11 @@ class LLMResponseCache:
     except Exception as e:
       # A cache is an optimization, so a backend failure must not abort the
       # invocation. ADK does not catch callback exceptions.
-      logger.error("Cache lookup failed, calling the model: %s", e)
+      if not self._config.ignore_errors:
+        raise
+      logger.error(
+          "Cache lookup failed, calling the model: %s", e, exc_info=True
+      )
       return None
 
     if cache_entry:
@@ -221,7 +230,9 @@ class LLMResponseCache:
     except Exception as e:
       # Returning the response the caller already paid for matters more
       # than caching it.
-      logger.error("Failed to cache response: %s", e)
+      if not self._config.ignore_errors:
+        raise
+      logger.error("Failed to cache response: %s", e, exc_info=True)
       return None
 
     logger.info("Cached response for prompt: %s", cache_key[:50])

--- a/src/adk_redis/cache/llm_cache.py
+++ b/src/adk_redis/cache/llm_cache.py
@@ -141,6 +141,12 @@ class LLMResponseCache:
     Returns:
         LlmResponse if cache hit, None to proceed with LLM call.
     """
+    # Any key still pending for this session belongs to an earlier turn
+    # whose after-model callback never ran, for instance because the model
+    # call raised. Drop it here so no later path can pop it and cache this
+    # turn's response under the earlier turn's prompt.
+    self._pending_prompts.pop(self._get_session_key(callback_context), None)
+
     if self._config.first_message_only and not self._is_first_message(
         callback_context
     ):

--- a/src/adk_redis/cache/llm_cache.py
+++ b/src/adk_redis/cache/llm_cache.py
@@ -148,7 +148,13 @@ class LLMResponseCache:
       return None
 
     cache_key = self._build_cache_key(prompt, callback_context)
-    cache_entry = await self._provider.check(cache_key)
+    try:
+      cache_entry = await self._provider.check(cache_key)
+    except Exception as e:
+      # A cache is an optimization, so a backend failure must not abort the
+      # invocation. ADK does not catch callback exceptions.
+      logger.error("Cache lookup failed, calling the model: %s", e)
+      return None
 
     if cache_entry:
       logger.info("Cache hit for prompt: %s", prompt[:50])
@@ -210,6 +216,13 @@ class LLMResponseCache:
       logger.debug("No text in response, skipping cache store")
       return None
 
-    await self._provider.store(cache_key, response_text)
+    try:
+      await self._provider.store(cache_key, response_text)
+    except Exception as e:
+      # Returning the response the caller already paid for matters more
+      # than caching it.
+      logger.error("Failed to cache response: %s", e)
+      return None
+
     logger.info("Cached response for prompt: %s", cache_key[:50])
     return None

--- a/src/adk_redis/cache/tool_cache.py
+++ b/src/adk_redis/cache/tool_cache.py
@@ -122,6 +122,11 @@ class ToolCache:
     Returns:
         Dict if cache hit (skips tool execution), None to proceed.
     """
+    # Any key still pending for this context belongs to an earlier call
+    # whose after-tool callback never ran. Drop it here so no later path
+    # can pop it and cache this result under the earlier call's key.
+    self._pending_calls.pop(self._get_session_key(tool_context), None)
+
     tool_name = tool.name
     if not self._should_cache_tool(tool_name):
       logger.debug("Tool %s not in cache list, skipping", tool_name)

--- a/src/adk_redis/cache/tool_cache.py
+++ b/src/adk_redis/cache/tool_cache.py
@@ -123,7 +123,13 @@ class ToolCache:
       return None
 
     cache_key = self._build_cache_key(tool_name, args, tool_context)
-    cache_entry = await self._provider.check(cache_key)
+    try:
+      cache_entry = await self._provider.check(cache_key)
+    except Exception as e:
+      # A cache is an optimization, so a backend failure must not abort the
+      # invocation. ADK does not catch callback exceptions.
+      logger.error("Cache lookup failed, running the tool: %s", e)
+      return None
 
     if cache_entry:
       logger.info("Cache hit for tool: %s", tool_name)
@@ -169,6 +175,13 @@ class ToolCache:
     except (TypeError, ValueError):
       response_str = str(tool_response)
 
-    await self._provider.store(cache_key, response_str)
+    try:
+      await self._provider.store(cache_key, response_str)
+    except Exception as e:
+      # Returning the tool result the caller already computed matters more
+      # than caching it.
+      logger.error("Failed to cache tool result: %s", e)
+      return None
+
     logger.info("Cached result for tool: %s", tool.name)
     return None

--- a/src/adk_redis/cache/tool_cache.py
+++ b/src/adk_redis/cache/tool_cache.py
@@ -27,7 +27,7 @@ from pydantic import Field
 
 from ._provider import BaseCacheProvider
 
-logger = logging.getLogger("adk_redis." + __name__)
+logger = logging.getLogger(__name__)
 
 
 class ToolCacheConfig(BaseModel):
@@ -38,12 +38,17 @@ class ToolCacheConfig(BaseModel):
       include_app_name: Include app name in cache key.
       include_user_id: Include user ID in cache key.
       include_session_id: Include session ID in cache key.
+      ignore_errors: Log cache backend failures and carry on with the tool
+          call instead of raising. Leave True in production, where a cache
+          must not be able to break an agent turn. Set False while
+          developing to see the failure instead of a log line.
   """
 
   tool_names: Optional[Set[str]] = Field(default=None)
   include_app_name: bool = Field(default=True)
   include_user_id: bool = Field(default=True)
   include_session_id: bool = Field(default=False)
+  ignore_errors: bool = Field(default=True)
 
 
 class ToolCache:
@@ -128,7 +133,11 @@ class ToolCache:
     except Exception as e:
       # A cache is an optimization, so a backend failure must not abort the
       # invocation. ADK does not catch callback exceptions.
-      logger.error("Cache lookup failed, running the tool: %s", e)
+      if not self._config.ignore_errors:
+        raise
+      logger.error(
+          "Cache lookup failed, running the tool: %s", e, exc_info=True
+      )
       return None
 
     if cache_entry:
@@ -180,7 +189,9 @@ class ToolCache:
     except Exception as e:
       # Returning the tool result the caller already computed matters more
       # than caching it.
-      logger.error("Failed to cache tool result: %s", e)
+      if not self._config.ignore_errors:
+        raise
+      logger.error("Failed to cache tool result: %s", e, exc_info=True)
       return None
 
     logger.info("Cached result for tool: %s", tool.name)

--- a/src/adk_redis/memory/long_term_memory.py
+++ b/src/adk_redis/memory/long_term_memory.py
@@ -43,7 +43,7 @@ from adk_redis.memory._utils import read_field
 from adk_redis.memory._utils import sanitize_managed_identifier
 from adk_redis.memory._utils import stable_memory_id
 
-logger = logging.getLogger("adk_redis." + __name__)
+logger = logging.getLogger(__name__)
 
 try:
   _agent_memory_client_module = import_module("agent_memory_client")

--- a/src/adk_redis/sessions/session_memory.py
+++ b/src/adk_redis/sessions/session_memory.py
@@ -45,7 +45,7 @@ from adk_redis.memory._utils import read_field
 from adk_redis.memory._utils import sanitize_managed_identifier
 from adk_redis.memory._utils import timestamp_to_datetime
 
-logger = logging.getLogger("adk_redis." + __name__)
+logger = logging.getLogger(__name__)
 
 _SESSION_ID_PREFIX = "adkredis"
 _MANAGED_SESSION_ID_LEN = 64

--- a/src/adk_redis/tools/memory/_base.py
+++ b/src/adk_redis/tools/memory/_base.py
@@ -29,7 +29,7 @@ from adk_redis.memory._utils import read_field
 from adk_redis.memory._utils import sanitize_managed_identifier
 from adk_redis.tools.memory._config import MemoryToolConfig
 
-logger = logging.getLogger("adk_redis." + __name__)
+logger = logging.getLogger(__name__)
 
 try:
   _agent_memory_client_module = import_module("agent_memory_client")

--- a/src/adk_redis/tools/memory/create.py
+++ b/src/adk_redis/tools/memory/create.py
@@ -28,7 +28,7 @@ from adk_redis.memory._utils import stable_memory_id
 from adk_redis.tools.memory._base import BaseMemoryTool
 from adk_redis.tools.memory._config import MemoryToolConfig
 
-logger = logging.getLogger("adk_redis." + __name__)
+logger = logging.getLogger(__name__)
 
 
 class CreateMemoryTool(BaseMemoryTool):

--- a/src/adk_redis/tools/memory/delete.py
+++ b/src/adk_redis/tools/memory/delete.py
@@ -28,7 +28,7 @@ from adk_redis.memory._utils import read_field
 from adk_redis.tools.memory._base import BaseMemoryTool
 from adk_redis.tools.memory._config import MemoryToolConfig
 
-logger = logging.getLogger("adk_redis." + __name__)
+logger = logging.getLogger(__name__)
 
 _PREFLIGHT_BATCH_SIZE = 10
 

--- a/src/adk_redis/tools/memory/get.py
+++ b/src/adk_redis/tools/memory/get.py
@@ -26,7 +26,7 @@ from adk_redis.memory._utils import read_field
 from adk_redis.tools.memory._base import BaseMemoryTool
 from adk_redis.tools.memory._config import MemoryToolConfig
 
-logger = logging.getLogger("adk_redis." + __name__)
+logger = logging.getLogger(__name__)
 
 
 class GetMemoryTool(BaseMemoryTool):

--- a/src/adk_redis/tools/memory/prompt.py
+++ b/src/adk_redis/tools/memory/prompt.py
@@ -26,7 +26,7 @@ from adk_redis.memory._utils import read_field
 from adk_redis.tools.memory._base import BaseMemoryTool
 from adk_redis.tools.memory._config import MemoryToolConfig
 
-logger = logging.getLogger("adk_redis." + __name__)
+logger = logging.getLogger(__name__)
 
 
 class MemoryPromptTool(BaseMemoryTool):

--- a/src/adk_redis/tools/memory/search.py
+++ b/src/adk_redis/tools/memory/search.py
@@ -27,7 +27,7 @@ from adk_redis.memory._utils import read_field
 from adk_redis.tools.memory._base import BaseMemoryTool
 from adk_redis.tools.memory._config import MemoryToolConfig
 
-logger = logging.getLogger("adk_redis." + __name__)
+logger = logging.getLogger(__name__)
 
 try:
   _agent_memory_filters_module = import_module("agent_memory_client.filters")

--- a/src/adk_redis/tools/memory/update.py
+++ b/src/adk_redis/tools/memory/update.py
@@ -26,7 +26,7 @@ from adk_redis.memory._utils import read_field
 from adk_redis.tools.memory._base import BaseMemoryTool
 from adk_redis.tools.memory._config import MemoryToolConfig
 
-logger = logging.getLogger("adk_redis." + __name__)
+logger = logging.getLogger(__name__)
 
 
 class UpdateMemoryTool(BaseMemoryTool):

--- a/tests/cache/test_fail_open.py
+++ b/tests/cache/test_fail_open.py
@@ -1,0 +1,171 @@
+# Copyright 2025 Redis, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A failing cache backend must not abort the ADK invocation.
+
+ADK awaits before_model_callback and before_tool_callback with no
+try/except, and outside its own model-error handling, so an exception
+raised by a cache provider ends the turn with no events emitted. A cache
+is an optimization, so both caches swallow provider failures and fall
+through to the model or the tool.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+from unittest.mock import MagicMock
+
+from google.adk.models.llm_request import LlmRequest
+from google.adk.models.llm_response import LlmResponse
+from google.genai import types
+import pytest
+
+from adk_redis.cache._provider import BaseCacheProvider
+from adk_redis.cache._provider import CacheEntry
+from adk_redis.cache.llm_cache import LLMResponseCache
+from adk_redis.cache.tool_cache import ToolCache
+
+
+class _BrokenProvider(BaseCacheProvider):
+  """A provider whose backend is unreachable."""
+
+  def __init__(self) -> None:
+    self.check_calls = 0
+    self.store_calls = 0
+
+  async def check(self, prompt: str, **kwargs: Any) -> Optional[CacheEntry]:
+    self.check_calls += 1
+    raise RuntimeError("backend unreachable")
+
+  async def store(
+      self,
+      prompt: str,
+      response: str,
+      metadata: Optional[dict[str, Any]] = None,
+      **kwargs: Any,
+  ) -> Optional[str]:
+    self.store_calls += 1
+    raise RuntimeError("backend unreachable")
+
+  async def delete_by_id(self, entry_id: str, **kwargs: Any) -> None:
+    raise RuntimeError("backend unreachable")
+
+  async def clear(self, **kwargs: Any) -> None:
+    raise RuntimeError("backend unreachable")
+
+  async def close(self) -> None:
+    return None
+
+
+def _callback_context() -> MagicMock:
+  """Build a callback context with no session history."""
+  context = MagicMock()
+  context.session = None
+  return context
+
+
+@pytest.mark.asyncio
+class TestLLMResponseCacheFailsOpen:
+  """LLMResponseCache degrades to a model call when the backend errors."""
+
+  async def test_check_failure_falls_through_to_the_model(self):
+    """A failed lookup returns None so ADK proceeds with the LLM call."""
+    provider = _BrokenProvider()
+    cache = LLMResponseCache(provider=provider)
+    request = LlmRequest(
+        contents=[
+            types.Content(
+                role="user", parts=[types.Part(text="What is Redis?")]
+            )
+        ]
+    )
+
+    result = await cache.before_model_callback(_callback_context(), request)
+
+    assert result is None
+    assert provider.check_calls == 1
+
+  async def test_store_failure_preserves_the_response(self):
+    """A failed store returns None so the model response passes through."""
+    provider = _BrokenProvider()
+    cache = LLMResponseCache(provider=provider)
+    context = _callback_context()
+    request = LlmRequest(
+        contents=[
+            types.Content(
+                role="user", parts=[types.Part(text="What is Redis?")]
+            )
+        ]
+    )
+    response = LlmResponse(
+        content=types.Content(
+            role="model", parts=[types.Part(text="An in-memory data store.")]
+        )
+    )
+
+    # The lookup must register a pending prompt for the store to be tried,
+    # so use a provider that only fails on write.
+    provider.check = _miss  # type: ignore[method-assign]
+    assert await cache.before_model_callback(context, request) is None
+
+    result = await cache.after_model_callback(context, response)
+
+    assert result is None
+    assert provider.store_calls == 1
+
+
+async def _miss(prompt: str, **kwargs: Any) -> Optional[CacheEntry]:
+  """Stand in for a lookup that completes and finds nothing."""
+  return None
+
+
+@pytest.mark.asyncio
+class TestToolCacheFailsOpen:
+  """ToolCache degrades to running the tool when the backend errors."""
+
+  async def test_check_failure_falls_through_to_the_tool(self):
+    """A failed lookup returns None so ADK executes the tool."""
+    provider = _BrokenProvider()
+    cache = ToolCache(provider=provider)
+    tool = MagicMock()
+    tool.name = "get_weather"
+
+    result = await cache.before_tool_callback(
+        tool=tool, args={"city": "London"}, tool_context=MagicMock()
+    )
+
+    assert result is None
+    assert provider.check_calls == 1
+
+  async def test_store_failure_preserves_the_tool_result(self):
+    """A failed store returns None so the tool result passes through."""
+    provider = _BrokenProvider()
+    cache = ToolCache(provider=provider)
+    provider.check = _miss  # type: ignore[method-assign]
+    tool = MagicMock()
+    tool.name = "get_weather"
+    tool_context = MagicMock()
+
+    await cache.before_tool_callback(
+        tool=tool, args={"city": "London"}, tool_context=tool_context
+    )
+    result = await cache.after_tool_callback(
+        tool=tool,
+        args={"city": "London"},
+        tool_context=tool_context,
+        tool_response={"temp": 12},
+    )
+
+    assert result is None
+    assert provider.store_calls == 1

--- a/tests/cache/test_fail_open.py
+++ b/tests/cache/test_fail_open.py
@@ -34,7 +34,9 @@ import pytest
 from adk_redis.cache._provider import BaseCacheProvider
 from adk_redis.cache._provider import CacheEntry
 from adk_redis.cache.llm_cache import LLMResponseCache
+from adk_redis.cache.llm_cache import LLMResponseCacheConfig
 from adk_redis.cache.tool_cache import ToolCache
+from adk_redis.cache.tool_cache import ToolCacheConfig
 
 
 class _BrokenProvider(BaseCacheProvider):
@@ -83,15 +85,9 @@ class TestLLMResponseCacheFailsOpen:
     """A failed lookup returns None so ADK proceeds with the LLM call."""
     provider = _BrokenProvider()
     cache = LLMResponseCache(provider=provider)
-    request = LlmRequest(
-        contents=[
-            types.Content(
-                role="user", parts=[types.Part(text="What is Redis?")]
-            )
-        ]
+    result = await cache.before_model_callback(
+        _callback_context(), _user_request()
     )
-
-    result = await cache.before_model_callback(_callback_context(), request)
 
     assert result is None
     assert provider.check_calls == 1
@@ -101,13 +97,7 @@ class TestLLMResponseCacheFailsOpen:
     provider = _BrokenProvider()
     cache = LLMResponseCache(provider=provider)
     context = _callback_context()
-    request = LlmRequest(
-        contents=[
-            types.Content(
-                role="user", parts=[types.Part(text="What is Redis?")]
-            )
-        ]
-    )
+    request = _user_request()
     response = LlmResponse(
         content=types.Content(
             role="model", parts=[types.Part(text="An in-memory data store.")]
@@ -128,6 +118,13 @@ class TestLLMResponseCacheFailsOpen:
 async def _miss(prompt: str, **kwargs: Any) -> Optional[CacheEntry]:
   """Stand in for a lookup that completes and finds nothing."""
   return None
+
+
+def _user_request(text: str = "What is Redis?") -> LlmRequest:
+  """Build a request carrying a single user turn."""
+  return LlmRequest(
+      contents=[types.Content(role="user", parts=[types.Part(text=text)])]
+  )
 
 
 @pytest.mark.asyncio
@@ -169,3 +166,32 @@ class TestToolCacheFailsOpen:
 
     assert result is None
     assert provider.store_calls == 1
+
+
+@pytest.mark.asyncio
+class TestIgnoreErrorsDisabled:
+  """ignore_errors=False lets a developer see the failure directly."""
+
+  async def test_llm_cache_raises_when_errors_are_not_ignored(self):
+    """The provider's exception reaches the caller unchanged."""
+    cache = LLMResponseCache(
+        provider=_BrokenProvider(),
+        config=LLMResponseCacheConfig(ignore_errors=False),
+    )
+
+    with pytest.raises(RuntimeError, match="backend unreachable"):
+      await cache.before_model_callback(_callback_context(), _user_request())
+
+  async def test_tool_cache_raises_when_errors_are_not_ignored(self):
+    """The provider's exception reaches the caller unchanged."""
+    cache = ToolCache(
+        provider=_BrokenProvider(),
+        config=ToolCacheConfig(ignore_errors=False),
+    )
+    tool = MagicMock()
+    tool.name = "get_weather"
+
+    with pytest.raises(RuntimeError, match="backend unreachable"):
+      await cache.before_tool_callback(
+          tool=tool, args={"city": "London"}, tool_context=MagicMock()
+      )

--- a/tests/cache/test_fail_open.py
+++ b/tests/cache/test_fail_open.py
@@ -70,6 +70,45 @@ class _BrokenProvider(BaseCacheProvider):
     return None
 
 
+class _RecordingProvider(BaseCacheProvider):
+  """A provider that records writes and can be made to fail lookups."""
+
+  def __init__(self) -> None:
+    self.fail_check = False
+    self.stored: list[tuple[str, str]] = []
+
+  async def check(self, prompt: str, **kwargs: Any) -> Optional[CacheEntry]:
+    if self.fail_check:
+      raise RuntimeError("backend unreachable")
+    return None
+
+  async def store(
+      self,
+      prompt: str,
+      response: str,
+      metadata: Optional[dict[str, Any]] = None,
+      **kwargs: Any,
+  ) -> Optional[str]:
+    self.stored.append((prompt, response))
+    return "entry-1"
+
+  async def delete_by_id(self, entry_id: str, **kwargs: Any) -> None:
+    return None
+
+  async def clear(self, **kwargs: Any) -> None:
+    return None
+
+  async def close(self) -> None:
+    return None
+
+
+def _model_response(text: str) -> LlmResponse:
+  """Build a model response carrying a single text part."""
+  return LlmResponse(
+      content=types.Content(role="model", parts=[types.Part(text=text)])
+  )
+
+
 def _callback_context() -> MagicMock:
   """Build a callback context with no session history."""
   context = MagicMock()
@@ -195,3 +234,63 @@ class TestIgnoreErrorsDisabled:
       await cache.before_tool_callback(
           tool=tool, args={"city": "London"}, tool_context=MagicMock()
       )
+
+
+@pytest.mark.asyncio
+class TestPendingStateIsNotReusedAcrossTurns:
+  """A turn must never cache its response under an earlier turn's key.
+
+  The pending key registered on a cache miss is popped by the after
+  callback. If the call in between raises, that key survives, and any
+  later turn that returns early without registering its own key would
+  otherwise have its response stored against the stale one.
+  """
+
+  async def test_llm_cache_does_not_store_under_a_stale_key(self):
+    """A failed lookup discards the earlier turn's pending prompt."""
+    provider = _RecordingProvider()
+    cache = LLMResponseCache(
+        provider=provider,
+        config=LLMResponseCacheConfig(first_message_only=False),
+    )
+    context = _callback_context()
+
+    # Turn one misses, registering a pending prompt, then its model call
+    # fails so the after callback never runs.
+    await cache.before_model_callback(context, _user_request("prompt one"))
+
+    # Turn two cannot reach the backend and falls through to the model.
+    provider.fail_check = True
+    await cache.before_model_callback(context, _user_request("prompt two"))
+    provider.fail_check = False
+
+    await cache.after_model_callback(context, _model_response("response two"))
+
+    assert provider.stored == []
+
+  async def test_tool_cache_does_not_store_under_a_stale_key(self):
+    """A failed lookup discards the earlier call's pending key."""
+    provider = _RecordingProvider()
+    cache = ToolCache(provider=provider)
+    tool = MagicMock()
+    tool.name = "get_weather"
+    tool_context = MagicMock()
+
+    await cache.before_tool_callback(
+        tool=tool, args={"city": "London"}, tool_context=tool_context
+    )
+
+    provider.fail_check = True
+    await cache.before_tool_callback(
+        tool=tool, args={"city": "Paris"}, tool_context=tool_context
+    )
+    provider.fail_check = False
+
+    await cache.after_tool_callback(
+        tool=tool,
+        args={"city": "Paris"},
+        tool_context=tool_context,
+        tool_response={"temp": 12},
+    )
+
+    assert provider.stored == []

--- a/tests/cache/test_provider.py
+++ b/tests/cache/test_provider.py
@@ -16,20 +16,22 @@
 
 from __future__ import annotations
 
-import inspect
+import importlib.metadata
 from typing import Any, Optional
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 import warnings
 
+from packaging.requirements import Requirement
 import pytest
 
 pytest.importorskip("redisvl")
 
 from redisvl.extensions.cache.llm import SemanticCache
 
-from adk_redis.cache._provider import _redisvl_supports_create_index
+from adk_redis.cache._provider import _accepts_create_index
+from adk_redis.cache._provider import _escape_glob
 from adk_redis.cache._provider import BaseCacheProvider
 from adk_redis.cache._provider import CacheEntry
 from adk_redis.cache._provider import LangCacheProvider
@@ -225,11 +227,18 @@ class TestLangCacheProviderEntryIds:
 
 def _make_redisvl_provider(
     mock_vectorizer: MagicMock,
+    config: Optional[RedisVLCacheProviderConfig] = None,
 ) -> tuple[RedisVLCacheProvider, MagicMock]:
-  """Build a RedisVLCacheProvider around a mocked SemanticCache."""
-  config = RedisVLCacheProviderConfig(name="test_cache")
-  with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
-    mock_cache = MagicMock()
+  """Build a RedisVLCacheProvider around a mocked SemanticCache.
+
+  The mock is spec'd so that a RedisVL release removing a method this
+  provider calls fails here rather than in production.
+  """
+  config = config or RedisVLCacheProviderConfig(name="test_cache")
+  with patch(
+      "redisvl.extensions.cache.llm.SemanticCache", autospec=True
+  ) as mock_cls:
+    mock_cache = MagicMock(spec=SemanticCache)
     mock_cls.return_value = mock_cache
     provider = RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
   return provider, mock_cache
@@ -260,6 +269,7 @@ class TestRedisVLCacheProviderEntryIds:
     """store() normalizes the backend Redis key to its entry ID."""
     provider, mock_cache = _make_redisvl_provider(mock_vectorizer)
     mock_cache.store.return_value = "test_cache:abc123"
+    mock_cache._get_prefix.return_value = "test_cache:"
 
     entry_id = await provider.store("prompt", "response")
 
@@ -279,28 +289,18 @@ class TestRedisVLCacheProviderCreateIndex:
 
   redisvl 0.26.0 added create_index. With create_index=False the RedisVL
   cache issues no index command at construction, so the provider works on a
-  credential that is denied FT.INFO and FT.CREATE.
+  credential that is denied FT.INFO and FT.CREATE. That construction is
+  proven against real Redis in the integration suite; these tests cover the
+  guards that run before RedisVL is reached.
   """
-
-  def test_create_index_false_is_forwarded(self, mock_vectorizer):
-    """create_index=False reaches SemanticCache with overwrite off."""
-    config = RedisVLCacheProviderConfig(
-        name="external_cache", create_index=False
-    )
-
-    with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
-      RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
-
-    _, kwargs = mock_cls.call_args
-    assert kwargs["create_index"] is False
-    assert kwargs["overwrite"] is False
-    assert kwargs["name"] == "external_cache"
 
   def test_create_index_false_with_overwrite_is_rejected(self, mock_vectorizer):
     """The contradiction is refused before any index command is issued."""
     config = RedisVLCacheProviderConfig(create_index=False, overwrite=True)
 
-    with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
+    with patch(
+        "redisvl.extensions.cache.llm.SemanticCache", autospec=True
+    ) as mock_cls:
       with pytest.raises(ValueError) as excinfo:
         RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
 
@@ -310,15 +310,20 @@ class TestRedisVLCacheProviderCreateIndex:
     mock_cls.assert_not_called()
 
   def test_create_index_false_requires_redisvl_026(self, mock_vectorizer):
-    """An older redisvl reports the required version, not an AttributeError."""
+    """An older redisvl reports the required version, not a silent no-op.
+
+    redisvl 0.18.2 accepts **kwargs, so an unrecognized create_index would
+    be swallowed and the provider would manage the index anyway.
+    """
     config = RedisVLCacheProviderConfig(create_index=False)
 
     with patch(
-        "adk_redis.cache._provider._redisvl_supports_create_index",
-        return_value=False,
+        "adk_redis.cache._provider._accepts_create_index", return_value=False
     ):
-      with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
-        with pytest.raises(ImportError) as excinfo:
+      with patch(
+          "redisvl.extensions.cache.llm.SemanticCache", autospec=True
+      ) as mock_cls:
+        with pytest.raises(ValueError) as excinfo:
           RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
 
     assert "redisvl>=0.26.0" in str(excinfo.value)
@@ -329,103 +334,89 @@ class TestRedisVLCacheProviderCreateIndex:
     config = RedisVLCacheProviderConfig()
 
     with patch(
-        "adk_redis.cache._provider._redisvl_supports_create_index",
-        return_value=False,
+        "adk_redis.cache._provider._accepts_create_index", return_value=False
     ):
-      with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
+      with patch(
+          "redisvl.extensions.cache.llm.SemanticCache", autospec=True
+      ) as mock_cls:
         RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
 
     _, kwargs = mock_cls.call_args
     assert "create_index" not in kwargs
 
-  def test_redisvl_value_error_is_reraised_with_config_guidance(
-      self, mock_vectorizer
-  ):
-    """A RedisVL rejection names the config fields that control the index."""
-    config = RedisVLCacheProviderConfig(name="mismatched")
+  def test_bad_redis_url_error_is_not_relabeled(self, mock_vectorizer):
+    """Only a schema mismatch gets index-configuration advice.
 
-    with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
-      mock_cls.side_effect = ValueError(
-          "Existing index mismatched schema does not match."
-      )
-      with pytest.raises(ValueError) as excinfo:
-        RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
+    A malformed redis_url already names the field to fix, so rewriting it
+    as an index problem would point the caller at the wrong knob.
+    """
+    config = RedisVLCacheProviderConfig(redis_url="http://not-a-redis-url")
+    mock_vectorizer.dims = 384
+    mock_vectorizer.dtype = "float32"
+
+    with pytest.raises(ValueError) as excinfo:
+      RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
 
     message = str(excinfo.value)
-    assert "mismatched" in message
-    assert "RedisVLCacheProviderConfig" in message
-    assert "overwrite" in message
-    assert isinstance(excinfo.value.__cause__, ValueError)
+    assert "scheme" in message.lower()
+    assert "overwrite" not in message
+    assert "create_index" not in message
 
-  def test_supports_create_index_matches_installed_redisvl(self):
-    """The capability probe agrees with the installed SemanticCache."""
-    signature = inspect.signature(SemanticCache.__init__)
-    assert _redisvl_supports_create_index() == (
-        "create_index" in signature.parameters
-    )
+  def test_probe_reads_the_constructor_signature(self):
+    """The probe asks the class it is about to call, not a proxy constant."""
+
+    class WithoutFlag:
+
+      def __init__(self, name: str):
+        pass
+
+    assert _accepts_create_index(SemanticCache) is True
+    assert _accepts_create_index(WithoutFlag) is False
+
+  def test_escape_glob_neutralizes_metacharacters(self):
+    """A cache name cannot widen the SCAN pattern used by clear().
+
+    Unescaped, "cache[ab]:*" matches unrelated cachea: and cacheb: keys
+    while missing the cache's own keys, so clear() would delete the wrong
+    entries.
+    """
+    assert _escape_glob("plain_cache") == "plain_cache"
+    assert _escape_glob("cache[ab]") == "cache\\[ab\\]"
+    assert _escape_glob("ca*che?") == "ca\\*che\\?"
 
 
 @pytest.mark.asyncio
 class TestRedisVLCacheProviderClear:
-  """clear() must work for both managed and externally managed indices."""
+  """clear() must not take the external path for a managed index."""
 
   async def test_clear_delegates_to_redisvl_when_managed(self, mock_vectorizer):
-    """The default path still calls SemanticCache.clear()."""
+    """The default path calls SemanticCache.clear() rather than scanning."""
     provider, mock_cache = _make_redisvl_provider(mock_vectorizer)
 
     await provider.clear()
 
     mock_cache.clear.assert_called_once_with()
+    mock_cache._get_redis_client.assert_not_called()
 
-  async def test_clear_scans_keys_for_external_index(self, mock_vectorizer):
-    """An external index is left in place while its entries are deleted."""
-    config = RedisVLCacheProviderConfig(
-        name="external_cache", create_index=False
+
+def test_version_gate_is_still_load_bearing():
+  """Delete the capability probe once the redisvl floor reaches 0.26.0.
+
+  _accepts_create_index and its ValueError branch exist only so the
+  declared floor can stay below the release that added create_index. This
+  test fails when that is no longer true, so the dead code goes with it.
+  """
+  specifiers = [
+      Requirement(req).specifier
+      for req in importlib.metadata.requires("adk-redis") or ()
+      if Requirement(req).name == "redisvl"
+  ]
+  assert specifiers, "adk-redis declares no redisvl requirement"
+
+  for specifier in specifiers:
+    assert specifier.contains("0.25.1"), (
+        "The declared redisvl floor no longer admits releases without"
+        " create_index, so _accepts_create_index and the version branch in"
+        " cache/_provider.py are dead code. Delete them and pass"
+        " create_index unconditionally."
     )
-    with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
-      mock_cache = MagicMock()
-      mock_cache._get_redis_client.return_value.scan_iter.return_value = iter(
-          ["external_cache:a", "external_cache:b"]
-      )
-      mock_cls.return_value = mock_cache
-      provider = RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
-
-    await provider.clear()
-
-    client = mock_cache._get_redis_client.return_value
-    _, scan_kwargs = client.scan_iter.call_args
-    assert scan_kwargs["match"] == "external_cache:*"
-    client.delete.assert_called_once_with(
-        "external_cache:a", "external_cache:b"
-    )
-    mock_cache.clear.assert_not_called()
-
-  async def test_delete_by_id_still_works_for_external_index(
-      self, mock_vectorizer
-  ):
-    """Targeted invalidation needs no index command, so it stays available."""
-    config = RedisVLCacheProviderConfig(create_index=False)
-    with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
-      mock_cache = MagicMock()
-      mock_cls.return_value = mock_cache
-      provider = RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
-
-    await provider.delete_by_id("abc123")
-
-    mock_cache.drop.assert_called_once_with(ids=["abc123"])
-
-  async def test_close_disconnects_without_a_live_client(self, mock_vectorizer):
-    """close() must not assume a client exists.
-
-    With create_index=False construction sends no command, so RedisVL may
-    never have opened a connection by the time close() runs.
-    """
-    config = RedisVLCacheProviderConfig(create_index=False)
-    with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
-      mock_cache = MagicMock()
-      mock_cls.return_value = mock_cache
-      provider = RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
-
-    await provider.close()
-
-    mock_cache.disconnect.assert_called_once_with()

--- a/tests/cache/test_provider.py
+++ b/tests/cache/test_provider.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import Any, Optional
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -26,6 +27,9 @@ import pytest
 
 pytest.importorskip("redisvl")
 
+from redisvl.extensions.cache.llm import SemanticCache
+
+from adk_redis.cache._provider import _redisvl_supports_create_index
 from adk_redis.cache._provider import BaseCacheProvider
 from adk_redis.cache._provider import CacheEntry
 from adk_redis.cache._provider import LangCacheProvider
@@ -82,7 +86,10 @@ class TestRedisVLCacheProviderImportPath:
     assert kwargs["ttl"] == 120
     assert kwargs["distance_threshold"] == 0.2
     assert kwargs["vectorizer"] is mock_vectorizer
-    assert kwargs["overwrite"] is True
+    assert kwargs["overwrite"] is False
+    # create_index is only forwarded when disabled, so the default path
+    # stays compatible with redisvl releases predating the flag.
+    assert "create_index" not in kwargs
 
 
 class TestBaseCacheProviderContract:
@@ -265,3 +272,160 @@ class TestRedisVLCacheProviderEntryIds:
     await provider.delete_by_id("abc123")
 
     mock_cache.drop.assert_called_once_with(ids=["abc123"])
+
+
+class TestRedisVLCacheProviderCreateIndex:
+  """create_index lets the provider attach to an external index.
+
+  redisvl 0.26.0 added create_index. With create_index=False the RedisVL
+  cache issues no index command at construction, so the provider works on a
+  credential that is denied FT.INFO and FT.CREATE.
+  """
+
+  def test_create_index_false_is_forwarded(self, mock_vectorizer):
+    """create_index=False reaches SemanticCache with overwrite off."""
+    config = RedisVLCacheProviderConfig(
+        name="external_cache", create_index=False
+    )
+
+    with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
+      RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
+
+    _, kwargs = mock_cls.call_args
+    assert kwargs["create_index"] is False
+    assert kwargs["overwrite"] is False
+    assert kwargs["name"] == "external_cache"
+
+  def test_create_index_false_with_overwrite_is_rejected(self, mock_vectorizer):
+    """The contradiction is refused before any index command is issued."""
+    config = RedisVLCacheProviderConfig(create_index=False, overwrite=True)
+
+    with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
+      with pytest.raises(ValueError) as excinfo:
+        RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
+
+    message = str(excinfo.value)
+    assert "create_index=False" in message
+    assert "overwrite=True" in message
+    mock_cls.assert_not_called()
+
+  def test_create_index_false_requires_redisvl_026(self, mock_vectorizer):
+    """An older redisvl reports the required version, not an AttributeError."""
+    config = RedisVLCacheProviderConfig(create_index=False)
+
+    with patch(
+        "adk_redis.cache._provider._redisvl_supports_create_index",
+        return_value=False,
+    ):
+      with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
+        with pytest.raises(ImportError) as excinfo:
+          RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
+
+    assert "redisvl>=0.26.0" in str(excinfo.value)
+    mock_cls.assert_not_called()
+
+  def test_default_config_works_on_older_redisvl(self, mock_vectorizer):
+    """The default path never sends create_index, so old releases still work."""
+    config = RedisVLCacheProviderConfig()
+
+    with patch(
+        "adk_redis.cache._provider._redisvl_supports_create_index",
+        return_value=False,
+    ):
+      with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
+        RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
+
+    _, kwargs = mock_cls.call_args
+    assert "create_index" not in kwargs
+
+  def test_redisvl_value_error_is_reraised_with_config_guidance(
+      self, mock_vectorizer
+  ):
+    """A RedisVL rejection names the config fields that control the index."""
+    config = RedisVLCacheProviderConfig(name="mismatched")
+
+    with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
+      mock_cls.side_effect = ValueError(
+          "Existing index mismatched schema does not match."
+      )
+      with pytest.raises(ValueError) as excinfo:
+        RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
+
+    message = str(excinfo.value)
+    assert "mismatched" in message
+    assert "RedisVLCacheProviderConfig" in message
+    assert "overwrite" in message
+    assert isinstance(excinfo.value.__cause__, ValueError)
+
+  def test_supports_create_index_matches_installed_redisvl(self):
+    """The capability probe agrees with the installed SemanticCache."""
+    signature = inspect.signature(SemanticCache.__init__)
+    assert _redisvl_supports_create_index() == (
+        "create_index" in signature.parameters
+    )
+
+
+@pytest.mark.asyncio
+class TestRedisVLCacheProviderClear:
+  """clear() must work for both managed and externally managed indices."""
+
+  async def test_clear_delegates_to_redisvl_when_managed(self, mock_vectorizer):
+    """The default path still calls SemanticCache.clear()."""
+    provider, mock_cache = _make_redisvl_provider(mock_vectorizer)
+
+    await provider.clear()
+
+    mock_cache.clear.assert_called_once_with()
+
+  async def test_clear_scans_keys_for_external_index(self, mock_vectorizer):
+    """An external index is left in place while its entries are deleted."""
+    config = RedisVLCacheProviderConfig(
+        name="external_cache", create_index=False
+    )
+    with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
+      mock_cache = MagicMock()
+      mock_cache._get_redis_client.return_value.scan_iter.return_value = iter(
+          ["external_cache:a", "external_cache:b"]
+      )
+      mock_cls.return_value = mock_cache
+      provider = RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
+
+    await provider.clear()
+
+    client = mock_cache._get_redis_client.return_value
+    _, scan_kwargs = client.scan_iter.call_args
+    assert scan_kwargs["match"] == "external_cache:*"
+    client.delete.assert_called_once_with(
+        "external_cache:a", "external_cache:b"
+    )
+    mock_cache.clear.assert_not_called()
+
+  async def test_delete_by_id_still_works_for_external_index(
+      self, mock_vectorizer
+  ):
+    """Targeted invalidation needs no index command, so it stays available."""
+    config = RedisVLCacheProviderConfig(create_index=False)
+    with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
+      mock_cache = MagicMock()
+      mock_cls.return_value = mock_cache
+      provider = RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
+
+    await provider.delete_by_id("abc123")
+
+    mock_cache.drop.assert_called_once_with(ids=["abc123"])
+
+  async def test_close_disconnects_without_a_live_client(self, mock_vectorizer):
+    """close() must not assume a client exists.
+
+    With create_index=False construction sends no command, so RedisVL may
+    never have opened a connection by the time close() runs.
+    """
+    config = RedisVLCacheProviderConfig(create_index=False)
+    with patch("redisvl.extensions.cache.llm.SemanticCache") as mock_cls:
+      mock_cache = MagicMock()
+      mock_cls.return_value = mock_cache
+      provider = RedisVLCacheProvider(config, vectorizer=mock_vectorizer)
+
+    await provider.close()
+
+    mock_cache.disconnect.assert_called_once_with()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,7 +23,7 @@ import uuid
 import pytest
 
 pytest.importorskip("redisvl")
-pytest.importorskip("redis")
+redis = pytest.importorskip("redis")
 
 
 REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6399")
@@ -32,8 +32,6 @@ REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6399")
 def _redis_reachable(url: str) -> bool:
   """Return True if a Redis instance with FT module is reachable at url."""
   try:
-    import redis
-
     client = redis.Redis.from_url(url, socket_timeout=1.0)
     client.ping()
     modules = client.module_list()
@@ -104,8 +102,6 @@ def unique_index_name():
   covers derived names such as "<name>_v2", so a reused Redis does not
   accumulate indices across runs.
   """
-  import redis
-
   name = f"adk_redis_it_{uuid.uuid4().hex[:8]}"
   try:
     yield name
@@ -144,8 +140,6 @@ def restricted_acl_url(redis_url: str):
   when the server will not provision such a user, or when it does not
   categorize FT.INFO the way this fixture's callers expect.
   """
-  import redis
-
   admin = redis.Redis.from_url(redis_url)
   username = f"acl_probe_{uuid.uuid4().hex[:8]}"
   password = uuid.uuid4().hex

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+from urllib.parse import urlparse
 import uuid
 
 import pytest
@@ -111,3 +112,64 @@ def unique_namespace() -> str:
 def unique_user_id() -> str:
   """Unique owner/user ID to isolate memory-backend test runs."""
   return f"user_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def restricted_acl_url(redis_url: str):
+  """Yield a Redis URL for a user granted +@read +@write and no @search.
+
+  This is the credential shape reported by customers whose search indices
+  are provisioned by a platform team: FT.INFO and FT.CREATE are denied,
+  while FT.SEARCH stays reachable through the @read category on Redis 8.2
+  and later. Skips when the server will not provision such a user, or when
+  it does not categorize FT.INFO the way this fixture's callers expect.
+  """
+  import redis
+
+  admin = redis.Redis.from_url(redis_url)
+  username = f"acl_probe_{uuid.uuid4().hex[:8]}"
+  password = uuid.uuid4().hex
+  try:
+    admin.execute_command(
+        "ACL",
+        "SETUSER",
+        username,
+        "on",
+        f">{password}",
+        "~*",
+        "+@read",
+        "+@write",
+    )
+  except redis.exceptions.ResponseError as e:
+    admin.close()
+    pytest.skip(f"cannot provision an ACL user on this Redis: {e}")
+
+  parsed = urlparse(redis_url)
+  netloc = f"{username}:{password}@{parsed.hostname}"
+  if parsed.port:
+    netloc = f"{netloc}:{parsed.port}"
+  url = parsed._replace(netloc=netloc).geturl()
+
+  try:
+    # Older servers and some managed flavors do not put module commands in
+    # any ACL category, so confirm the grant actually withholds FT.INFO
+    # before a caller asserts on that.
+    scoped = redis.Redis.from_url(url)
+    try:
+      denied = False
+      try:
+        scoped.execute_command("FT.INFO", "acl_probe_missing_index")
+      except redis.exceptions.ResponseError as e:
+        # An allowed FT.INFO reports an unknown index instead. redis-py
+        # strips the NOPERM prefix, so match on the message body.
+        denied = "no permissions" in str(e).lower()
+    finally:
+      scoped.close()
+    if not denied:
+      pytest.skip("FT.INFO is not denied by +@read +@write on this Redis")
+    yield url
+  finally:
+    try:
+      admin.execute_command("ACL", "DELUSER", username)
+    finally:
+      admin.close()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -138,11 +138,11 @@ def unique_user_id() -> str:
 def restricted_acl_url(redis_url: str):
   """Yield a Redis URL for a user granted +@read +@write and no @search.
 
-  This is the credential shape reported by customers whose search indices
-  are provisioned by a platform team: FT.INFO and FT.CREATE are denied,
-  while FT.SEARCH stays reachable through the @read category on Redis 8.2
-  and later. Skips when the server will not provision such a user, or when
-  it does not categorize FT.INFO the way this fixture's callers expect.
+  This is the credential shape used where search indices are provisioned
+  by a platform team: FT.INFO and FT.CREATE are denied, while FT.SEARCH
+  stays reachable through the @read category on Redis 8.2 and later. Skips
+  when the server will not provision such a user, or when it does not
+  categorize FT.INFO the way this fixture's callers expect.
   """
   import redis
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -97,9 +97,29 @@ def redis_url() -> str:
 
 
 @pytest.fixture
-def unique_index_name() -> str:
-  """Unique index name to isolate test runs."""
-  return f"adk_redis_it_{uuid.uuid4().hex[:8]}"
+def unique_index_name():
+  """Unique index name to isolate test runs.
+
+  Every index whose name starts with this one is dropped afterwards, which
+  covers derived names such as "<name>_v2", so a reused Redis does not
+  accumulate indices across runs.
+  """
+  import redis
+
+  name = f"adk_redis_it_{uuid.uuid4().hex[:8]}"
+  try:
+    yield name
+  finally:
+    if REDIS_OK:
+      client = redis.Redis.from_url(REDIS_URL)
+      try:
+        for existing in client.execute_command("FT._LIST"):
+          if isinstance(existing, bytes):
+            existing = existing.decode()
+          if str(existing).startswith(name):
+            client.execute_command("FT.DROPINDEX", existing, "DD")
+      finally:
+        client.close()
 
 
 @pytest.fixture

--- a/tests/integration/test_sql_and_cache_end_to_end.py
+++ b/tests/integration/test_sql_and_cache_end_to_end.py
@@ -19,8 +19,6 @@ from __future__ import annotations
 import hashlib
 import math
 from unittest.mock import MagicMock
-from urllib.parse import urlparse
-import uuid
 
 import pytest
 import redis
@@ -166,6 +164,44 @@ def _index_names(redis_url: str) -> set[str]:
     client.close()
 
 
+def _provision_cache_index(
+    redis_url: str, name: str, *, dims: int, prefix: str | None = None
+) -> None:
+  """Create a cache index out of band, standing in for a platform team.
+
+  Args:
+    redis_url: Connection string used to create the index.
+    name: Index name, which the provider must be pointed at.
+    dims: Vector dimensions to declare for the prompt vector.
+    prefix: Key prefix to index. Defaults to the name, matching RedisVL.
+  """
+  schema = IndexSchema.from_dict(
+      {
+          "index": {
+              "name": name,
+              "prefix": prefix if prefix is not None else name,
+              "storage_type": "hash",
+          },
+          "fields": [
+              {"name": "prompt", "type": "text"},
+              {"name": "response", "type": "text"},
+              {
+                  "name": "prompt_vector",
+                  "type": "vector",
+                  "attrs": {
+                      "dims": dims,
+                      "algorithm": "flat",
+                      "datatype": "float32",
+                      "distance_metric": "cosine",
+                  },
+              },
+          ],
+      }
+  )
+  index = SearchIndex(schema, redis_url=redis_url)
+  index.create(overwrite=True)
+
+
 @REQUIRES_REDIS
 class TestRedisVLCacheProviderExternalIndex:
   """create_index=False attaches to an index adk-redis did not create."""
@@ -192,32 +228,36 @@ class TestRedisVLCacheProviderExternalIndex:
   async def test_round_trip_against_pre_provisioned_index(
       self, redis_url: str, vectorizer, unique_index_name
   ):
-    """An externally provisioned index serves check(), store(), and clear()."""
-    # Stand in for the platform team: provision the index out of band, then
-    # attach a second provider that is told not to manage it.
+    """An externally provisioned index serves the whole runtime path."""
     owner_config = RedisVLCacheProviderConfig(
         redis_url=redis_url, name=unique_index_name, ttl=60
     )
     owner = RedisVLCacheProvider(owner_config, vectorizer=vectorizer)
     assert unique_index_name in _index_names(redis_url)
 
-    attached_config = RedisVLCacheProviderConfig(
-        redis_url=redis_url,
-        name=unique_index_name,
-        ttl=60,
-        create_index=False,
+    attached = RedisVLCacheProvider(
+        RedisVLCacheProviderConfig(
+            redis_url=redis_url,
+            name=unique_index_name,
+            ttl=60,
+            create_index=False,
+        ),
+        vectorizer=vectorizer,
     )
-    attached = RedisVLCacheProvider(attached_config, vectorizer=vectorizer)
     try:
       entry_id = await attached.store("hello world", "hi there")
+      assert entry_id is not None
       hit = await attached.check("hello world")
       assert hit is not None
       assert hit.response == "hi there"
-      assert entry_id is not None
+
+      await attached.delete_by_id(entry_id)
+      assert await attached.check("hello world") is None
 
       # clear() must remove entries without dropping the external index.
+      await attached.store("another prompt", "another response")
       await attached.clear()
-      assert await attached.check("hello world") is None
+      assert await attached.check("another prompt") is None
       assert unique_index_name in _index_names(redis_url)
     finally:
       await attached.close()
@@ -225,70 +265,160 @@ class TestRedisVLCacheProviderExternalIndex:
       await owner.close()
 
   @pytest.mark.asyncio
-  async def test_delete_by_id_on_pre_provisioned_index(
+  async def test_clear_leaves_a_neighbouring_cache_intact(
       self, redis_url: str, vectorizer, unique_index_name
   ):
-    """Targeted invalidation works while the index is externally managed."""
-    owner_config = RedisVLCacheProviderConfig(
-        redis_url=redis_url, name=unique_index_name, ttl=60
+    """clear() must only delete keys under its own cache prefix.
+
+    Cache entry keys are "<name>:<entry_id>", so a scan pattern missing the
+    trailing separator would also delete a "<name>_v2:" cache's entries.
+    Note this asserts deletion scope only: RedisVL gives the index itself
+    the bare name as its prefix, so a neighbouring cache whose name extends
+    this one is visible to both indices.
+    """
+    neighbour_name = f"{unique_index_name}_v2"
+    owner = RedisVLCacheProvider(
+        RedisVLCacheProviderConfig(
+            redis_url=redis_url, name=unique_index_name, ttl=60
+        ),
+        vectorizer=vectorizer,
     )
-    owner = RedisVLCacheProvider(owner_config, vectorizer=vectorizer)
-    attached_config = RedisVLCacheProviderConfig(
-        redis_url=redis_url,
-        name=unique_index_name,
-        ttl=60,
-        create_index=False,
+    neighbour = RedisVLCacheProvider(
+        RedisVLCacheProviderConfig(
+            redis_url=redis_url, name=neighbour_name, ttl=60
+        ),
+        vectorizer=vectorizer,
     )
-    attached = RedisVLCacheProvider(attached_config, vectorizer=vectorizer)
+    attached = RedisVLCacheProvider(
+        RedisVLCacheProviderConfig(
+            redis_url=redis_url,
+            name=unique_index_name,
+            ttl=60,
+            create_index=False,
+        ),
+        vectorizer=vectorizer,
+    )
+    try:
+      await attached.store("shared prompt", "from the first cache")
+      await neighbour.store("shared prompt", "from the neighbour")
+
+      client = redis.Redis.from_url(redis_url)
+      try:
+        await attached.clear()
+
+        assert not list(client.scan_iter(match=f"{unique_index_name}:*"))
+        assert list(client.scan_iter(match=f"{neighbour_name}:*"))
+      finally:
+        client.close()
+      survivor = await neighbour.check("shared prompt")
+      assert survivor is not None
+      assert survivor.response == "from the neighbour"
+    finally:
+      await attached.close()
+      await neighbour.clear()
+      await neighbour.close()
+      await owner.close()
+
+  @pytest.mark.asyncio
+  async def test_mismatched_index_misses_silently(
+      self, redis_url: str, vectorizer, unique_index_name
+  ):
+    """A mismatched attached index yields misses, not errors.
+
+    This is the failure the guide warns about: entries are written and
+    TTLs set, every lookup misses, and nothing raises. Pinned here because
+    the docs promise this shape and a future RedisVL could change it.
+    """
+    # Same name and prefix as the provider expects, wrong vector width.
+    _provision_cache_index(redis_url, unique_index_name, dims=384)
+    attached = RedisVLCacheProvider(
+        RedisVLCacheProviderConfig(
+            redis_url=redis_url,
+            name=unique_index_name,
+            ttl=60,
+            create_index=False,
+        ),
+        vectorizer=vectorizer,
+    )
     try:
       entry_id = await attached.store("what is redis", "a data store")
       assert entry_id is not None
-
-      await attached.delete_by_id(entry_id)
-
       assert await attached.check("what is redis") is None
-      assert unique_index_name in _index_names(redis_url)
+    finally:
+      await attached.clear()
+      await attached.close()
+
+  @pytest.mark.asyncio
+  async def test_absent_index_raises_rather_than_missing(
+      self, redis_url: str, vectorizer, unique_index_name
+  ):
+    """A wrong index name raises on the first check(), it is not silent."""
+    attached = RedisVLCacheProvider(
+        RedisVLCacheProviderConfig(
+            redis_url=redis_url,
+            name=unique_index_name,
+            ttl=60,
+            create_index=False,
+        ),
+        vectorizer=vectorizer,
+    )
+    try:
+      await attached.store("what is redis", "a data store")
+      with pytest.raises(RedisSearchError, match="No such index"):
+        await attached.check("what is redis")
     finally:
       await attached.close()
-      await owner.clear()
-      await owner.close()
 
+  @pytest.mark.asyncio
+  async def test_schema_mismatch_names_the_config_field(
+      self, redis_url: str, vectorizer, unique_index_name
+  ):
+    """The managed path reports a drifted schema with a usable remedy.
 
-@pytest.fixture
-def restricted_acl_url(redis_url: str):
-  """Yield a Redis URL for a user granted +@read +@write and no @search.
+    This is the error the overwrite=False default exists to surface, so it
+    is asserted against a real index rather than a mocked exception.
+    """
+    _provision_cache_index(redis_url, unique_index_name, dims=384)
+    try:
+      with pytest.raises(ValueError) as excinfo:
+        RedisVLCacheProvider(
+            RedisVLCacheProviderConfig(
+                redis_url=redis_url, name=unique_index_name, ttl=60
+            ),
+            vectorizer=vectorizer,
+        )
 
-  This is the credential shape reported by customers whose search indices
-  are provisioned by a platform team: FT.INFO and FT.CREATE are denied,
-  while FT.SEARCH remains reachable through the @read category.
-  """
-  admin = redis.Redis.from_url(redis_url)
-  username = f"adk_redis_it_{uuid.uuid4().hex[:8]}"
-  password = "it-secret"
-  try:
-    admin.execute_command(
-        "ACL",
-        "SETUSER",
-        username,
-        "on",
-        f">{password}",
-        "~*",
-        "+@read",
-        "+@write",
+      message = str(excinfo.value)
+      assert unique_index_name in message
+      assert "overwrite=True" in message
+    finally:
+      redis.Redis.from_url(redis_url).execute_command(
+          "FT.DROPINDEX", unique_index_name, "DD"
+      )
+
+  @pytest.mark.asyncio
+  async def test_overwrite_rebuilds_a_drifted_index(
+      self, redis_url: str, vectorizer, unique_index_name
+  ):
+    """overwrite=True is the documented escape hatch for a drifted schema."""
+    _provision_cache_index(redis_url, unique_index_name, dims=384)
+    provider = RedisVLCacheProvider(
+        RedisVLCacheProviderConfig(
+            redis_url=redis_url,
+            name=unique_index_name,
+            ttl=60,
+            overwrite=True,
+        ),
+        vectorizer=vectorizer,
     )
-  except redis.exceptions.ResponseError as e:
-    admin.close()
-    pytest.skip(f"cannot provision an ACL user on this Redis: {e}")
-
-  parsed = urlparse(redis_url)
-  netloc = f"{username}:{password}@{parsed.hostname}"
-  if parsed.port:
-    netloc = f"{netloc}:{parsed.port}"
-  try:
-    yield parsed._replace(netloc=netloc).geturl()
-  finally:
-    admin.execute_command("ACL", "DELUSER", username)
-    admin.close()
+    try:
+      await provider.store("what is redis", "a data store")
+      hit = await provider.check("what is redis")
+      assert hit is not None
+      assert hit.response == "a data store"
+    finally:
+      await provider.clear()
+      await provider.close()
 
 
 @REQUIRES_REDIS
@@ -296,10 +426,10 @@ class TestRedisVLCacheProviderRestrictedAcl:
   """The cache must attach to an index on a credential denied @search."""
 
   @pytest.mark.asyncio
-  async def test_default_path_is_denied_without_search_grant(
+  async def test_default_path_reports_the_denied_command(
       self, restricted_acl_url: str, vectorizer, unique_index_name
   ):
-    """create_index=True cannot even probe the index on this credential."""
+    """create_index=True cannot probe the index, and says what to do."""
     config = RedisVLCacheProviderConfig(
         redis_url=restricted_acl_url, name=unique_index_name, ttl=60
     )
@@ -307,7 +437,9 @@ class TestRedisVLCacheProviderRestrictedAcl:
     with pytest.raises(RedisSearchError) as excinfo:
       RedisVLCacheProvider(config, vectorizer=vectorizer)
 
-    assert "FT.INFO" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "FT.INFO" in message
+    assert "create_index=False" in message
 
   @pytest.mark.asyncio
   async def test_round_trip_on_restricted_acl(
@@ -318,14 +450,12 @@ class TestRedisVLCacheProviderRestrictedAcl:
       unique_index_name,
   ):
     """A pre-provisioned index serves the full runtime path on +@read."""
-    # The platform team provisions the index with a privileged credential.
     owner = RedisVLCacheProvider(
         RedisVLCacheProviderConfig(
             redis_url=redis_url, name=unique_index_name, ttl=60
         ),
         vectorizer=vectorizer,
     )
-
     attached = RedisVLCacheProvider(
         RedisVLCacheProviderConfig(
             redis_url=restricted_acl_url,
@@ -347,7 +477,6 @@ class TestRedisVLCacheProviderRestrictedAcl:
       await attached.delete_by_id(entry_id)
       assert await attached.check("what is redis") is None
 
-      # clear() takes the prefix scan path, needing no index command.
       await attached.store("another prompt", "another response")
       await attached.clear()
       assert await attached.check("another prompt") is None

--- a/tests/integration/test_sql_and_cache_end_to_end.py
+++ b/tests/integration/test_sql_and_cache_end_to_end.py
@@ -367,6 +367,8 @@ class TestRedisVLCacheProviderExternalIndex:
       with pytest.raises(RedisSearchError, match="No such index"):
         await attached.check("what is redis")
     finally:
+      # The prefix scan needs no index, so it reclaims the written entry.
+      await attached.clear()
       await attached.close()
 
   @pytest.mark.asyncio

--- a/tests/integration/test_sql_and_cache_end_to_end.py
+++ b/tests/integration/test_sql_and_cache_end_to_end.py
@@ -19,8 +19,12 @@ from __future__ import annotations
 import hashlib
 import math
 from unittest.mock import MagicMock
+from urllib.parse import urlparse
+import uuid
 
 import pytest
+import redis
+from redisvl.exceptions import RedisSearchError
 from redisvl.index import SearchIndex
 from redisvl.schema import IndexSchema
 from redisvl.utils.vectorize.text.custom import CustomTextVectorizer
@@ -148,3 +152,207 @@ class TestRedisVLCacheProviderEndToEnd:
     finally:
       await provider.clear()
       await provider.close()
+
+
+def _index_names(redis_url: str) -> set[str]:
+  """Return the search index names that exist on the server."""
+  client = redis.Redis.from_url(redis_url)
+  try:
+    return {
+        name.decode() if isinstance(name, bytes) else str(name)
+        for name in client.execute_command("FT._LIST")
+    }
+  finally:
+    client.close()
+
+
+@REQUIRES_REDIS
+class TestRedisVLCacheProviderExternalIndex:
+  """create_index=False attaches to an index adk-redis did not create."""
+
+  @pytest.mark.asyncio
+  async def test_construction_issues_no_index_command(
+      self, redis_url: str, vectorizer, unique_index_name
+  ):
+    """A missing index stays missing, proving no FT.CREATE was sent."""
+    config = RedisVLCacheProviderConfig(
+        redis_url=redis_url,
+        name=unique_index_name,
+        ttl=60,
+        create_index=False,
+    )
+
+    provider = RedisVLCacheProvider(config, vectorizer=vectorizer)
+    try:
+      assert unique_index_name not in _index_names(redis_url)
+    finally:
+      await provider.close()
+
+  @pytest.mark.asyncio
+  async def test_round_trip_against_pre_provisioned_index(
+      self, redis_url: str, vectorizer, unique_index_name
+  ):
+    """An externally provisioned index serves check(), store(), and clear()."""
+    # Stand in for the platform team: provision the index out of band, then
+    # attach a second provider that is told not to manage it.
+    owner_config = RedisVLCacheProviderConfig(
+        redis_url=redis_url, name=unique_index_name, ttl=60
+    )
+    owner = RedisVLCacheProvider(owner_config, vectorizer=vectorizer)
+    assert unique_index_name in _index_names(redis_url)
+
+    attached_config = RedisVLCacheProviderConfig(
+        redis_url=redis_url,
+        name=unique_index_name,
+        ttl=60,
+        create_index=False,
+    )
+    attached = RedisVLCacheProvider(attached_config, vectorizer=vectorizer)
+    try:
+      entry_id = await attached.store("hello world", "hi there")
+      hit = await attached.check("hello world")
+      assert hit is not None
+      assert hit.response == "hi there"
+      assert entry_id is not None
+
+      # clear() must remove entries without dropping the external index.
+      await attached.clear()
+      assert await attached.check("hello world") is None
+      assert unique_index_name in _index_names(redis_url)
+    finally:
+      await attached.close()
+      await owner.clear()
+      await owner.close()
+
+  @pytest.mark.asyncio
+  async def test_delete_by_id_on_pre_provisioned_index(
+      self, redis_url: str, vectorizer, unique_index_name
+  ):
+    """Targeted invalidation works while the index is externally managed."""
+    owner_config = RedisVLCacheProviderConfig(
+        redis_url=redis_url, name=unique_index_name, ttl=60
+    )
+    owner = RedisVLCacheProvider(owner_config, vectorizer=vectorizer)
+    attached_config = RedisVLCacheProviderConfig(
+        redis_url=redis_url,
+        name=unique_index_name,
+        ttl=60,
+        create_index=False,
+    )
+    attached = RedisVLCacheProvider(attached_config, vectorizer=vectorizer)
+    try:
+      entry_id = await attached.store("what is redis", "a data store")
+      assert entry_id is not None
+
+      await attached.delete_by_id(entry_id)
+
+      assert await attached.check("what is redis") is None
+      assert unique_index_name in _index_names(redis_url)
+    finally:
+      await attached.close()
+      await owner.clear()
+      await owner.close()
+
+
+@pytest.fixture
+def restricted_acl_url(redis_url: str):
+  """Yield a Redis URL for a user granted +@read +@write and no @search.
+
+  This is the credential shape reported by customers whose search indices
+  are provisioned by a platform team: FT.INFO and FT.CREATE are denied,
+  while FT.SEARCH remains reachable through the @read category.
+  """
+  admin = redis.Redis.from_url(redis_url)
+  username = f"adk_redis_it_{uuid.uuid4().hex[:8]}"
+  password = "it-secret"
+  try:
+    admin.execute_command(
+        "ACL",
+        "SETUSER",
+        username,
+        "on",
+        f">{password}",
+        "~*",
+        "+@read",
+        "+@write",
+    )
+  except redis.exceptions.ResponseError as e:
+    admin.close()
+    pytest.skip(f"cannot provision an ACL user on this Redis: {e}")
+
+  parsed = urlparse(redis_url)
+  netloc = f"{username}:{password}@{parsed.hostname}"
+  if parsed.port:
+    netloc = f"{netloc}:{parsed.port}"
+  try:
+    yield parsed._replace(netloc=netloc).geturl()
+  finally:
+    admin.execute_command("ACL", "DELUSER", username)
+    admin.close()
+
+
+@REQUIRES_REDIS
+class TestRedisVLCacheProviderRestrictedAcl:
+  """The cache must attach to an index on a credential denied @search."""
+
+  @pytest.mark.asyncio
+  async def test_default_path_is_denied_without_search_grant(
+      self, restricted_acl_url: str, vectorizer, unique_index_name
+  ):
+    """create_index=True cannot even probe the index on this credential."""
+    config = RedisVLCacheProviderConfig(
+        redis_url=restricted_acl_url, name=unique_index_name, ttl=60
+    )
+
+    with pytest.raises(RedisSearchError) as excinfo:
+      RedisVLCacheProvider(config, vectorizer=vectorizer)
+
+    assert "FT.INFO" in str(excinfo.value)
+
+  @pytest.mark.asyncio
+  async def test_round_trip_on_restricted_acl(
+      self,
+      redis_url: str,
+      restricted_acl_url: str,
+      vectorizer,
+      unique_index_name,
+  ):
+    """A pre-provisioned index serves the full runtime path on +@read."""
+    # The platform team provisions the index with a privileged credential.
+    owner = RedisVLCacheProvider(
+        RedisVLCacheProviderConfig(
+            redis_url=redis_url, name=unique_index_name, ttl=60
+        ),
+        vectorizer=vectorizer,
+    )
+
+    attached = RedisVLCacheProvider(
+        RedisVLCacheProviderConfig(
+            redis_url=restricted_acl_url,
+            name=unique_index_name,
+            ttl=60,
+            create_index=False,
+        ),
+        vectorizer=vectorizer,
+    )
+    try:
+      entry_id = await attached.store("what is redis", "a data store")
+      assert entry_id is not None
+
+      # FT.SEARCH carries the @read category, so check() still resolves.
+      hit = await attached.check("what is redis")
+      assert hit is not None
+      assert hit.response == "a data store"
+
+      await attached.delete_by_id(entry_id)
+      assert await attached.check("what is redis") is None
+
+      # clear() takes the prefix scan path, needing no index command.
+      await attached.store("another prompt", "another response")
+      await attached.clear()
+      assert await attached.check("another prompt") is None
+      assert unique_index_name in _index_names(redis_url)
+    finally:
+      await attached.close()
+      await owner.clear()
+      await owner.close()


### PR DESCRIPTION
## The problem

A user runs Redis with an ACL granting `+@read +@write` but not `@search`. On that credential `FT.INFO` and `FT.CREATE` are both denied, so RedisVL can neither ask whether an index exists nor create one. Their index is provisioned out of band by a platform team.

`RedisVLCacheProvider` could not be constructed at all on such a credential: it hardcoded `SemanticCache(..., overwrite=True)`, which probes with `FT.INFO` and then issues `FT.CREATE`. RedisVL 0.26.0 adds `create_index`, which this PR adopts.

## What you can now do

```python
provider = RedisVLCacheProvider(
    config=RedisVLCacheProviderConfig(
        redis_url="redis://cache-user:password@redis.internal:6379",
        name="my_cache",       # must match the pre-provisioned index
        create_index=False,    # issue no index command at all
    ),
    vectorizer=vectorizer,
)
```

`create_index` defaults to `True`, so nothing changes unless you ask for it. The flag is forwarded to RedisVL only when disabled, and requesting it on an older redisvl raises a `ValueError` naming the version, so **the `redisvl` floor stays at `>=0.18.2`** and users of the `[search]`, `[langcache]`, and `[sql]` extras are not forced to upgrade for a cache feature they may not use.

## Two changes that affect existing users

**`overwrite` no longer defaults to `True`.** It is now a config field defaulting to `False`, matching RedisVL's own default. The old behavior dropped and recreated the index on every provider construction, which put `FT.DROPINDEX` and `FT.CREATE` on a path most callers use only to read and write entries, and it hid the case it was meant to handle: on a schema mismatch the index was silently rebuilt while entries embedded by the previous model stayed in the keyspace, unindexed.

If your index schema no longer matches your config, construction now raises where it previously succeeded. Since providers are typically built at module import, that surfaces as a startup failure. To migrate, set `overwrite=True` for one deployment to rebuild, or drop the index out of band.

**A failing cache no longer breaks the agent turn.** ADK awaits `before_model_callback` with no `try`/`except`, and outside its own model-error handling, so `on_model_error_callback` never fires for a callback exception. A provider error therefore ended the invocation with no events emitted, after the user's message was already in the session. On the after-model path it was worse: the store runs before the response is yielded, so a failed write discarded a response the caller had already paid for.

`LLMResponseCache` and `ToolCache` now log and fall through, matching how `memory/long_term_memory.py` already degrades. Set `ignore_errors=False` on either config to raise instead, which is what you want while wiring a cache up or asserting in a test. Construction errors are never absorbed.

## Bugs found and fixed

- **`clear()` could delete the wrong keys.** The `SCAN` pattern was built from the unescaped cache name, so a name containing a glob metacharacter matched unrelated keys. Verified on Redis 8.4: pattern `cache[ab]:*` returns `cachea:y` and `cacheb:z` and misses `cache[ab]:x` entirely.
- **`RedisSearchError` escaped the error wrap.** It is not a `ValueError`, so the exact failure this feature exists to solve arrived as a bare RedisVL message with no mention of `create_index`.
- **A malformed `redis_url` was mislabeled.** The wrap advised "Adjust name, create_index, or overwrite" for any `ValueError`, including a bad URL and any `pydantic.ValidationError`. Only a schema mismatch is rewritten now.
- **`close()` raised `AttributeError`** when the provider never opened a connection, newly reachable because `create_index=False` sends nothing to Redis.
- **Loggers were named with a doubled prefix.** Every module used `"adk_redis." + __name__` while `__name__` already began with `adk_redis`, so the real logger was `adk_redis.adk_redis.cache.llm_cache` and configuring `adk_redis.cache` had no effect. Filtering on the top-level `adk_redis` logger is unchanged.
- **CI had no Redis service**, so every integration test skipped on push and pull request. Added, which is how several of the findings above surfaced.

## Verified against Redis 8.4, not assumed

The ACL guidance is measured, and the results were surprising enough to be worth stating here:

| Command | Categories | Allowed by `+@read +@write` |
|---|---|---|
| `FT.SEARCH` | `@read`, `@search` | Yes |
| `FT.CREATE`, `FT.INFO` | `@search` | No |

So `check()` works fine on that credential, and only index management is denied. Two consequences that are easy to get wrong:

- The ACL key pattern must be a superset of the **index** prefix, and RedisVL gives the index the bare cache name while writing keys under `<name>:`. The credential needs `~my_cache*`, not the natural looking `~my_cache:*`.
- `check()` refreshes each hit's TTL, so the read path issues `EXPIRE` and needs `@write` too.

Because RedisVL validates nothing about an attached index, the docs also record which mismatches are loud and which are silent. A wrong or absent index `name` raises on the first `check()`; wrong dimensions, prefix, storage type, or distance metric silently miss on every prompt. Both shapes have tests, since they are promises the docs now make.

On pre-8.2 Redis Software and Redis Cloud, and OSS 7.x with the RediSearch module, module commands belong to no ACL category at all, so the grant must name `+FT.SEARCH`. The guide says so.

## Testing

`make check` passes, and integration tests now run in CI. The suite includes a real ACL user granted `+@read +@write`, which reproduces this scenario end to end, and a test asserting no index command is issued at construction. Net test coverage grew where it buys something and shrank where it did not: three redundant tests deleted, two that asserted against mocked exceptions replaced with real-Redis equivalents, mocks given specs so a RedisVL API removal fails in CI, and a guard test that fails once the redisvl floor reaches 0.26.0 so the version gate gets deleted rather than living forever.

## Follow-ups, not in this PR

Three upstream RedisVL asks came out of this work: `clear()` is refused on an externally managed index although it issues no index command, `store()` returns a full Redis key where `check()` and `drop()` speak in bare entry IDs, and `BaseCache.clear()` has the same unescaped-glob bug fixed here. Landing the first two lets adk-redis delete local workarounds.

Deferred pre-existing issues, all unrelated to this change: the `_pending_prompts` leak on failed turns, `ToolCache` keying off `id(tool_context)`, no timeout on provider calls, and `extra="forbid"` on the config models.
