### PR TITLE
chore(release): bump project version to 0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `adk-redis` are recorded in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.0.10] - 2026-08-20
 
 ### Added
 
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `redisvl>=0.26.0`; the package floor stays at 0.18.2 and the default path
   is unchanged.
 - `RedisVLCacheProviderConfig.overwrite` exposes index overwrite as a
-  configuration option.
+  configuration option. It cannot be combined with `create_index=False`;
+  that pairing raises a `ValueError` at construction.
 - `ignore_errors` on `LLMResponseCacheConfig` and `ToolCacheConfig`
   defaults to True, logging cache backend failures and carrying on. Set it
   to False while developing to raise instead of reading a log line.
@@ -62,6 +63,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `adk_redis.adk_redis.cache.llm_cache` and configuring
   `adk_redis.cache` had no effect. Filtering on the top-level `adk_redis`
   logger is unchanged.
+
+### Documentation
+
+- New managed memory quickstart example, the smallest memory agent on the
+  managed `redis-agent-memory` backend, with no Docker or Agent Memory
+  Server required.
+- The examples index labels every example with its memory backend and its
+  runner, making clear which examples require the self-hosted
+  `opensource-agent-memory` backend.
+- The caching guides cover `create_index`, `overwrite`, and
+  `ignore_errors`.
 
 ## [0.0.9] - 2026-07-31
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "adk-redis"
-version = "0.0.9"
+version = "0.0.10"
 description = "Redis integrations for Google's Agent Development Kit (ADK)"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Closes out the `Unreleased` changelog section as 0.0.10 and bumps the package version. No source changes.

## Changes

- `pyproject.toml`: version `0.0.9` -> `0.0.10`.
- `CHANGELOG.md`: `## [Unreleased]` -> `## [0.0.10] - 2026-08-20`.
- `CHANGELOG.md`: record the `ValueError` raised when `create_index=False` is combined with `overwrite=True`, which the Added entry for `overwrite` did not mention.
- `CHANGELOG.md`: add a Documentation section for the examples work from #29 (managed memory quickstart, per-example backend and runner labels), which had no changelog entry.

## Release contents

Everything since the `0.0.9` tag: the cache provider work in #30 and the examples and docs parity pass in #29.

Headline items for 0.0.10:

- `RedisVLCacheProviderConfig.create_index=False` attaches the cache to a search index provisioned outside adk-redis, for credentials denied `FT.INFO` and `FT.CREATE`. Requires `redisvl>=0.26.0`.
- `ignore_errors` on `LLMResponseCacheConfig` and `ToolCacheConfig`, default `True`: a cache backend failure no longer aborts the invocation.
- **Breaking:** `RedisVLCacheProvider` no longer forces `overwrite=True`. An existing index is reused rather than dropped and recreated. A drifted schema now raises a `ValueError` naming `overwrite` instead of silently rebuilding the index.
- Integration tests now run in CI against a Redis 8.4 service; they were silently skipped before.

## Checks

- `make format` clean, no files changed.
- Not yet tagged. `0.0.10` should be tagged after this merges.